### PR TITLE
🧹 Rename package from angular-sleeper to xomper-frontend

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -3,7 +3,7 @@
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
-    "angular-sleeper": {
+    "xomper-frontend": {
       "projectType": "application",
       "schematics": {
         "@schematics/angular:component": {
@@ -17,7 +17,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist/angular-sleeper",
+            "outputPath": "dist/xomper-frontend",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": ["zone.js"],
@@ -66,10 +66,10 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
             "production": {
-              "buildTarget": "angular-sleeper:build:production"
+              "buildTarget": "xomper-frontend:build:production"
             },
             "development": {
-              "buildTarget": "angular-sleeper:build:development"
+              "buildTarget": "xomper-frontend:build:development"
             }
           },
           "defaultConfiguration": "development"
@@ -77,7 +77,7 @@
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "buildTarget": "angular-sleeper:build"
+            "buildTarget": "xomper-frontend:build"
           }
         },
         "test": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "angular-sleeper",
+  "name": "xomper-frontend",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "angular-sleeper",
+      "name": "xomper-frontend",
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^18.2.14",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular-sleeper",
+  "name": "xomper-frontend",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
Updates the package name across `package.json`, `package-lock.json`, and `angular.json`.

Closes #46