### PR TITLE
fix: update deploy path after package rename

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -64,7 +64,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
-        run: aws s3 sync ./dist/angular-sleeper s3://xomper.xomware.com --delete
+        run: aws s3 sync ./dist/xomper-frontend s3://xomper.xomware.com --delete
 
       - name: Invalidate CloudFront cache
         env:


### PR DESCRIPTION
The package rename (#48) changed Angular output from `dist/angular-sleeper` to `dist/xomper-frontend`, breaking the S3 deploy step.