### PR TITLE
chore: bump GitHub Actions to Node-24-compatible versions

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
           cache: 'npm'


### PR DESCRIPTION
## Summary

Bumps pinned GitHub Actions to Node-24-compatible major versions ahead of the Node 20 deprecation deadline (~2026-06-02 per GitHub Actions runner deprecation notice).

## Version bumps applied (where present)

- `actions/checkout` → v6
- `actions/setup-python` → v6
- `actions/setup-node` → v6
- `hashicorp/setup-terraform` → v4
- `aws-actions/configure-aws-credentials` → v6
- `actions/cache` → v5
- `actions/upload-artifact` → v7
- `actions/download-artifact` → v6

## Test plan

- CI passes on this PR
- No Node 20 deprecation annotation in the workflow run