### PR TITLE
#88 feat: s7b — Admin Announcements + Tables + Audit + Cron + Logs

### DIFF
--- a/docs/features/web-ios-parity/s7-admin-portal/EXECUTION_LOG.md
+++ b/docs/features/web-ios-parity/s7-admin-portal/EXECUTION_LOG.md
@@ -156,3 +156,16 @@
 - **Result**: skipped
 
 ---
+
+## PR 7b Run — 2026-06-04
+
+---
+
+## [2026-06-04 10:00] — Phase 0: Issue + Branch
+
+- **Action**: Created GitHub issue #88 `web-ios-parity s7b: Admin portal — Announcements + Tables + Audit + Cron + Logs` with label `epic:web-ios-parity`. Created branch `feature/88-admin-portal-b` off master (e4a4d7f). Confirmed no in-flight PRs on affected paths.
+- **Files changed**: none
+- **Decisions**: Issue number is 88 (not 87 — 87 was the PR for 7a).
+- **Result**: success
+
+---

--- a/docs/features/web-ios-parity/s7-admin-portal/PLAN.md
+++ b/docs/features/web-ios-parity/s7-admin-portal/PLAN.md
@@ -2,7 +2,7 @@
 
 **Status**: In Progress (PR 7a complete, 7b pending)
 **Created**: 2026-06-04
-**Last updated**: 2026-06-04 (PR 7a shipped: issue #86, branch feature/86-admin-portal-a)
+**Last updated**: 2026-06-04 (PR 7b shipped: issue #88, branch feature/88-admin-portal-b)
 **Epic**: [`../PLAN.md`](../PLAN.md)
 **Brainstorm**: [`../BRAINSTORM.md`](../BRAINSTORM.md)
 
@@ -367,23 +367,23 @@ Sequenced. Steps 1–4 are Phase 0 / shared. Steps 5–17 are PR 7a. Steps 18–
 
 **PR 7b — CRUD + Ops**
 
-- [ ] 18. Extend `AnnouncementsService`: add `listAdmin()`, `getById()`, `create()`, `update()`, `softDelete()`.
-- [ ] 19. Build `AdminAnnouncementsListComponent` (chips, delete confirm, pending spinner).
-- [ ] 20. Build `AdminAnnouncementEditComponent` (Reactive Form, 3-state expiry diff).
-- [ ] 21. Wire `/admin/announcements` and `/admin/announcements/:id` (incl. `new` sentinel) routes.
-- [ ] 22. Add `TablesService` + `WhitelistedUser` (admin-scope) + `WhitelistedLeague` models.
-- [ ] 23. Build `AdminTablesMenuComponent`.
-- [ ] 24. Build `AdminTablesUsersComponent` + `AdminUserEditComponent` (email regex validator + diff-on-save).
-- [ ] 25. Build `AdminTablesLeaguesComponent` + `AdminLeagueEditComponent`.
-- [ ] 26. Wire `/admin/tables`, `/admin/tables/users`, `/admin/tables/users/:id`, `/admin/tables/leagues`, `/admin/tables/leagues/:id` routes.
-- [ ] 27. Add `AuditService` + `AuditEntry` model.
-- [ ] 28. Build `AdminAuditFeedComponent` (cursor pagination + tableMissing empty state).
-- [ ] 29. Build `AdminAuditDetailComponent` (3 collapsible JSON blocks; first-page fallback when store empty on direct nav).
-- [ ] 30. Wire `/admin/audit` and `/admin/audit/:id` routes.
-- [ ] 31. Add `CronService` + `CronSetting` model.
-- [ ] 32. Build `AdminCronSettingsComponent` (test-mode banner, per-row pending spinner).
-- [ ] 33. Wire `/admin/cron-settings` route.
-- [ ] 34. Build `AdminLogsComponent` placeholder + wire `/admin/logs` route.
+- [x] 18. Extend `AnnouncementsService`: add `listAdmin()`, `getById()`, `create()`, `update()`, `softDelete()`.
+- [x] 19. Build `AdminAnnouncementsListComponent` (chips, delete confirm, pending spinner).
+- [x] 20. Build `AdminAnnouncementEditComponent` (Reactive Form, 3-state expiry diff).
+- [x] 21. Wire `/admin/announcements` and `/admin/announcements/:id` (incl. `new` sentinel) routes.
+- [x] 22. Add `TablesService` + `WhitelistedUser` (admin-scope) + `WhitelistedLeague` models.
+- [x] 23. Build `AdminTablesMenuComponent`.
+- [x] 24. Build `AdminTablesUsersComponent` + `AdminUserEditComponent` (email regex validator + diff-on-save).
+- [x] 25. Build `AdminTablesLeaguesComponent` + `AdminLeagueEditComponent`.
+- [x] 26. Wire `/admin/tables`, `/admin/tables/users`, `/admin/tables/users/:id`, `/admin/tables/leagues`, `/admin/tables/leagues/:id` routes.
+- [x] 27. Add `AuditService` + `AuditEntry` model.
+- [x] 28. Build `AdminAuditFeedComponent` (cursor pagination + tableMissing empty state).
+- [x] 29. Build `AdminAuditDetailComponent` (3 collapsible JSON blocks; first-page fallback when store empty on direct nav).
+- [x] 30. Wire `/admin/audit` and `/admin/audit/:id` routes.
+- [x] 31. Add `CronService` + `CronSetting` model.
+- [x] 32. Build `AdminCronSettingsComponent` (test-mode banner, per-row pending spinner).
+- [x] 33. Wire `/admin/cron-settings` route.
+- [x] 34. Build `AdminLogsComponent` placeholder + wire `/admin/logs` route.
 - [ ] 34a. Run `/ultrareview` on PR 7b; open PR.
 - [ ] 35. Both PRs merged → mark `s7-admin-portal` sub-issue done on XomBoard.
 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -173,9 +173,95 @@ const routes: Routes = [
             (m) => m.AdminEmailArchiveDetailComponent,
           ),
       },
-      // PR 7b routes (placeholders — components ship in 7b)
-      // Registered now so the shell can navigate to them even before 7b merges.
-      // They will 404-redirect gracefully via the catch-all.
+      // PR 7b — Announcements
+      {
+        path: 'announcements',
+        loadComponent: () =>
+          import('./pages/admin/announcements/list/admin-announcements-list.component').then(
+            (m) => m.AdminAnnouncementsListComponent,
+          ),
+      },
+      {
+        path: 'announcements/new',
+        loadComponent: () =>
+          import('./pages/admin/announcements/edit/admin-announcement-edit.component').then(
+            (m) => m.AdminAnnouncementEditComponent,
+          ),
+      },
+      {
+        path: 'announcements/:id',
+        loadComponent: () =>
+          import('./pages/admin/announcements/edit/admin-announcement-edit.component').then(
+            (m) => m.AdminAnnouncementEditComponent,
+          ),
+      },
+      // PR 7b — Tables
+      {
+        path: 'tables',
+        loadComponent: () =>
+          import('./pages/admin/tables/admin-tables-menu.component').then(
+            (m) => m.AdminTablesMenuComponent,
+          ),
+      },
+      {
+        path: 'tables/users',
+        loadComponent: () =>
+          import('./pages/admin/tables/users/list/admin-tables-users.component').then(
+            (m) => m.AdminTablesUsersComponent,
+          ),
+      },
+      {
+        path: 'tables/users/:id',
+        loadComponent: () =>
+          import('./pages/admin/tables/users/edit/admin-user-edit.component').then(
+            (m) => m.AdminUserEditComponent,
+          ),
+      },
+      {
+        path: 'tables/leagues',
+        loadComponent: () =>
+          import('./pages/admin/tables/leagues/list/admin-tables-leagues.component').then(
+            (m) => m.AdminTablesLeaguesComponent,
+          ),
+      },
+      {
+        path: 'tables/leagues/:id',
+        loadComponent: () =>
+          import('./pages/admin/tables/leagues/edit/admin-league-edit.component').then(
+            (m) => m.AdminLeagueEditComponent,
+          ),
+      },
+      // PR 7b — Audit
+      {
+        path: 'audit',
+        loadComponent: () =>
+          import('./pages/admin/audit/feed/admin-audit-feed.component').then(
+            (m) => m.AdminAuditFeedComponent,
+          ),
+      },
+      {
+        path: 'audit/:id',
+        loadComponent: () =>
+          import('./pages/admin/audit/detail/admin-audit-detail.component').then(
+            (m) => m.AdminAuditDetailComponent,
+          ),
+      },
+      // PR 7b — Cron Settings
+      {
+        path: 'cron-settings',
+        loadComponent: () =>
+          import('./pages/admin/cron-settings/admin-cron-settings.component').then(
+            (m) => m.AdminCronSettingsComponent,
+          ),
+      },
+      // PR 7b — Logs placeholder
+      {
+        path: 'logs',
+        loadComponent: () =>
+          import('./pages/admin/logs/admin-logs.component').then(
+            (m) => m.AdminLogsComponent,
+          ),
+      },
     ],
   },
   { path: 'team-analyzer', redirectTo: 'team', pathMatch: 'full' },

--- a/src/app/models/admin-validation.ts
+++ b/src/app/models/admin-validation.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared admin validation helpers.
+ * Mirrors iOS AdminValidation enum from UserEditView.swift.
+ */
+
+/**
+ * RFC5322-simplified email regex.
+ * Mirrors iOS: ^[A-Z0-9a-z._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$
+ */
+export const ADMIN_EMAIL_REGEX = /^[A-Z0-9a-z._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$/
+
+export function isValidAdminEmail(email: string): boolean {
+  return ADMIN_EMAIL_REGEX.test(email.trim())
+}

--- a/src/app/models/audit-entry.model.ts
+++ b/src/app/models/audit-entry.model.ts
@@ -1,0 +1,74 @@
+/**
+ * One row from the Supabase admin_audit table.
+ * Mirrors iOS AuditEntry from AuditEntry.swift.
+ *
+ * before / after / metadata are stored as JSONB blobs — arbitrary JSON.
+ * The detail view pretty-prints them via JSON.stringify(value, null, 2).
+ */
+export interface AuditEntry {
+  id: string
+  createdAt: string          // ISO-8601
+  actorUserId: string
+  action: string
+  targetTable: string | null
+  targetId: string | null
+  before: unknown | null
+  after: unknown | null
+  metadata: unknown | null
+}
+
+export interface AuditEntryRaw {
+  id: string
+  created_at: string
+  actor_user_id: string
+  action: string
+  target_table?: string | null
+  target_id?: string | null
+  before?: unknown | null
+  after?: unknown | null
+  metadata?: unknown | null
+}
+
+export interface AuditListResponse {
+  Success?: boolean
+  count?: number
+  rows: AuditEntryRaw[]
+  next_cursor?: string | null
+  table_missing?: boolean
+}
+
+export function mapAuditEntry(raw: AuditEntryRaw): AuditEntry {
+  return {
+    id: raw.id,
+    createdAt: raw.created_at,
+    actorUserId: raw.actor_user_id,
+    action: raw.action,
+    targetTable: raw.target_table ?? null,
+    targetId: raw.target_id ?? null,
+    before: raw.before ?? null,
+    after: raw.after ?? null,
+    metadata: raw.metadata ?? null,
+  }
+}
+
+/** Human-friendly verb. Mirrors iOS AuditEntry.actionDisplay. */
+export function auditActionDisplay(action: string): string {
+  const map: Record<string, string> = {
+    'users.update':   'Updated user',
+    'leagues.update': 'Updated league',
+    'reports.flag':   'Flagged report',
+    'email.test':     'Sent test email',
+  }
+  return map[action] ?? action
+}
+
+/** Lucide / material icon name suitable for the action. Web equivalent of iOS SF Symbols. */
+export function auditActionIcon(action: string): string {
+  const map: Record<string, string> = {
+    'users.update':   'user',
+    'leagues.update': 'building-2',
+    'reports.flag':   'flag',
+    'email.test':     'send',
+  }
+  return map[action] ?? 'circle-dashed'
+}

--- a/src/app/models/cron-setting.model.ts
+++ b/src/app/models/cron-setting.model.ts
@@ -1,0 +1,59 @@
+/**
+ * One row from the Supabase admin_cron_settings table.
+ * Mirrors iOS CronSetting from CronSetting.swift.
+ *
+ * cronKey is the primary key (unique). description may be absent for
+ * freshly-seeded rows without a human label.
+ */
+export interface CronSetting {
+  cronKey: string
+  enabled: boolean
+  testMode: boolean
+  description: string | null
+  updatedAt: string | null   // ISO-8601
+}
+
+export interface CronSettingRaw {
+  cron_key: string
+  enabled?: boolean
+  test_mode?: boolean
+  description?: string | null
+  updated_at?: string | null
+}
+
+export interface CronSettingsListResponse {
+  count?: number
+  rows: CronSettingRaw[]
+  table_missing?: boolean
+}
+
+export interface CronSettingUpdateResponse {
+  cron_key: string
+  enabled: boolean
+  test_mode: boolean
+}
+
+export function mapCronSetting(raw: CronSettingRaw): CronSetting {
+  return {
+    cronKey: raw.cron_key,
+    enabled: raw.enabled ?? true,
+    testMode: raw.test_mode ?? false,
+    description: raw.description ?? null,
+    updatedAt: raw.updated_at ?? null,
+  }
+}
+
+export function mapCronSettingUpdate(raw: CronSettingUpdateResponse): Partial<CronSetting> {
+  return {
+    cronKey: raw.cron_key,
+    enabled: raw.enabled,
+    testMode: raw.test_mode,
+  }
+}
+
+/** Fallback display title: prefer description, then cronKey. Mirrors iOS displayTitle. */
+export function cronDisplayTitle(setting: CronSetting): string {
+  return setting.description && setting.description.trim()
+    ? setting.description
+    : setting.cronKey
+}

--- a/src/app/models/league-announcement.model.ts
+++ b/src/app/models/league-announcement.model.ts
@@ -31,6 +31,30 @@ export interface AnnouncementsListResponse {
   rows: LeagueAnnouncementRaw[]
 }
 
+/** Admin list — includes inactive + expired rows. */
+export interface AdminAnnouncementsListResponse {
+  Success?: boolean
+  count?: number
+  rows: LeagueAnnouncementRaw[]
+  table_missing?: boolean
+}
+
+/** Response shape for create / update / delete mutations. */
+export interface AnnouncementMutationResponse {
+  Success?: boolean
+  row: LeagueAnnouncementRaw
+}
+
+/** Input for create — all required fields. */
+export interface AnnouncementCreateInput {
+  title: string
+  body: string
+  priority: 'critical' | 'info'
+  is_active: boolean
+  display_order: number
+  expires_at?: string | null
+}
+
 export function mapAnnouncement(raw: LeagueAnnouncementRaw): LeagueAnnouncement {
   return {
     id: raw.id,

--- a/src/app/models/whitelisted-league.model.ts
+++ b/src/app/models/whitelisted-league.model.ts
@@ -1,0 +1,66 @@
+/**
+ * Admin-scope league model.
+ * Mirrors iOS WhitelistedLeague from WhitelistedLeague.swift.
+ *
+ * Wire shape (snake_case from GET /admin/leagues-list):
+ * {
+ *   "id": "uuid",
+ *   "league_id": "sleeper-league-id",
+ *   "league_name": "League Name",
+ *   "season": "2025",
+ *   "is_active": true,
+ *   "is_dynasty": true,
+ *   "has_taxi": true,
+ *   "divisions": 2,
+ *   "size": 12
+ * }
+ */
+export interface WhitelistedLeague {
+  id: string
+  leagueId: string
+  leagueName: string
+  season: string
+  isActive: boolean
+  isDynasty: boolean
+  hasTaxi: boolean
+  divisions: number | null
+  size: number | null
+}
+
+export interface WhitelistedLeagueRaw {
+  id: string
+  league_id: string
+  league_name: string
+  season: string
+  is_active?: boolean
+  is_dynasty?: boolean
+  has_taxi?: boolean
+  divisions?: number | null
+  size?: number | null
+}
+
+export interface LeaguesListResponse {
+  leagues: WhitelistedLeagueRaw[]
+  count?: number
+}
+
+export interface LeagueUpdateResponse {
+  Success?: boolean
+  league_id?: string
+  before?: unknown
+  after?: unknown
+}
+
+export function mapWhitelistedLeague(raw: WhitelistedLeagueRaw): WhitelistedLeague {
+  return {
+    id: raw.id,
+    leagueId: raw.league_id,
+    leagueName: raw.league_name,
+    season: raw.season,
+    isActive: raw.is_active ?? false,
+    isDynasty: raw.is_dynasty ?? false,
+    hasTaxi: raw.has_taxi ?? false,
+    divisions: raw.divisions ?? null,
+    size: raw.size ?? null,
+  }
+}

--- a/src/app/models/whitelisted-user.model.ts
+++ b/src/app/models/whitelisted-user.model.ts
@@ -1,0 +1,63 @@
+/**
+ * Admin-scope user model.
+ * Mirrors iOS WhitelistedUser from Profile.swift — includes isAdmin + role
+ * fields that the public-read profile model omits.
+ *
+ * Wire shape (snake_case from GET /admin/users-list):
+ * {
+ *   "id": "uuid",
+ *   "email": "user@example.com",
+ *   "sleeper_username": "username",
+ *   "sleeper_user_id": "123456789",
+ *   "display_name": "Display Name",
+ *   "role": "member",
+ *   "is_active": true,
+ *   "is_admin": false
+ * }
+ */
+export interface WhitelistedUser {
+  id: string
+  email: string
+  sleeperUsername: string | null
+  sleeperUserId: string | null
+  displayName: string | null
+  role: string | null
+  isActive: boolean
+  isAdmin: boolean
+}
+
+export interface WhitelistedUserRaw {
+  id: string
+  email: string
+  sleeper_username?: string | null
+  sleeper_user_id?: string | null
+  display_name?: string | null
+  role?: string | null
+  is_active?: boolean
+  is_admin?: boolean
+}
+
+export interface UsersListResponse {
+  users: WhitelistedUserRaw[]
+  count?: number
+}
+
+export interface UserUpdateResponse {
+  Success?: boolean
+  user_id?: string
+  before?: unknown
+  after?: unknown
+}
+
+export function mapWhitelistedUser(raw: WhitelistedUserRaw): WhitelistedUser {
+  return {
+    id: raw.id,
+    email: raw.email,
+    sleeperUsername: raw.sleeper_username ?? null,
+    sleeperUserId: raw.sleeper_user_id ?? null,
+    displayName: raw.display_name ?? null,
+    role: raw.role ?? null,
+    isActive: raw.is_active ?? false,
+    isAdmin: raw.is_admin ?? false,
+  }
+}

--- a/src/app/pages/admin/announcements/edit/admin-announcement-edit.component.html
+++ b/src/app/pages/admin/announcements/edit/admin-announcement-edit.component.html
@@ -1,0 +1,101 @@
+<div class="announcement-edit">
+  <div class="edit-header">
+    <button class="btn-back" (click)="cancel()">← Back</button>
+    <h2>{{ isNew ? 'New Announcement' : 'Edit Announcement' }}</h2>
+  </div>
+
+  <div *ngIf="isLoading" class="state-loading">
+    <p>Loading…</p>
+  </div>
+
+  <form *ngIf="!isLoading" [formGroup]="form" (ngSubmit)="submit()" class="edit-form">
+
+    <!-- Title -->
+    <div class="field-group">
+      <label for="title">Title</label>
+      <input
+        id="title"
+        type="text"
+        formControlName="title"
+        placeholder="Announcement title"
+        autocomplete="off"
+      />
+      <p *ngIf="form.get('title')?.touched && form.get('title')?.hasError('required')" class="field-error">Title is required.</p>
+      <p *ngIf="form.get('title')?.touched && form.get('title')?.hasError('maxlength')" class="field-error">Max 200 characters.</p>
+    </div>
+
+    <!-- Body -->
+    <div class="field-group">
+      <label for="body">Body</label>
+      <p class="field-hint">Supports <strong>**bold**</strong> and [links](url)</p>
+      <textarea
+        id="body"
+        formControlName="body"
+        rows="5"
+        placeholder="Announcement body…"
+      ></textarea>
+      <p *ngIf="form.get('body')?.touched && form.get('body')?.hasError('required')" class="field-error">Body is required.</p>
+    </div>
+
+    <!-- Priority -->
+    <div class="field-group">
+      <label>Priority</label>
+      <div class="radio-group">
+        <label class="radio-label">
+          <input type="radio" formControlName="priority" value="info" />
+          Info
+        </label>
+        <label class="radio-label">
+          <input type="radio" formControlName="priority" value="critical" />
+          Critical
+        </label>
+      </div>
+    </div>
+
+    <!-- Active toggle -->
+    <div class="field-group field-row">
+      <label for="isActive">Active</label>
+      <input id="isActive" type="checkbox" formControlName="isActive" />
+    </div>
+
+    <!-- Display order -->
+    <div class="field-group">
+      <label for="displayOrder">Display Order</label>
+      <input
+        id="displayOrder"
+        type="number"
+        formControlName="displayOrder"
+        min="0"
+      />
+    </div>
+
+    <!-- Expiry -->
+    <div class="field-group field-row">
+      <label for="hasExpiry">Has Expiry</label>
+      <input id="hasExpiry" type="checkbox" formControlName="hasExpiry" />
+    </div>
+
+    <div *ngIf="hasExpiryCtrl.value" class="field-group">
+      <label for="expiresAt">Expires At</label>
+      <input
+        id="expiresAt"
+        type="datetime-local"
+        formControlName="expiresAt"
+      />
+      <p *ngIf="form.get('expiresAt')?.touched && form.get('expiresAt')?.hasError('required')" class="field-error">Expiry date is required when Has Expiry is on.</p>
+    </div>
+
+    <!-- Feedback -->
+    <p *ngIf="error" class="feedback-error">{{ error }}</p>
+    <p *ngIf="successMessage" class="feedback-success">{{ successMessage }}</p>
+
+    <!-- Actions -->
+    <div class="form-actions">
+      <button type="button" class="btn-secondary" (click)="cancel()">Cancel</button>
+      <button type="submit" class="btn-primary" [disabled]="form.invalid || isSaving">
+        <span *ngIf="isSaving" class="spinner-sm"></span>
+        <span *ngIf="!isSaving">{{ isNew ? 'Create' : 'Save' }}</span>
+      </button>
+    </div>
+  </form>
+</div>

--- a/src/app/pages/admin/announcements/edit/admin-announcement-edit.component.scss
+++ b/src/app/pages/admin/announcements/edit/admin-announcement-edit.component.scss
@@ -1,0 +1,169 @@
+.announcement-edit {
+  padding: 24px;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.edit-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 32px;
+
+  h2 {
+    margin: 0;
+    font-size: 1.4rem;
+    font-weight: 600;
+  }
+}
+
+.btn-back {
+  background: none;
+  border: none;
+  color: #10b981;
+  cursor: pointer;
+  font-size: 0.95rem;
+  padding: 0;
+
+  &:hover { text-decoration: underline; }
+}
+
+.edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  &.field-row {
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+
+    label { margin-bottom: 0; }
+  }
+
+  label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.7);
+  }
+}
+
+.field-hint {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.4);
+  margin: 0;
+}
+
+input[type="text"],
+input[type="number"],
+input[type="datetime-local"],
+textarea {
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  color: #fff;
+  font-size: 0.9rem;
+  padding: 10px 12px;
+  outline: none;
+  resize: vertical;
+
+  &:focus {
+    border-color: #10b981;
+  }
+
+  &::placeholder { color: rgba(255, 255, 255, 0.3); }
+}
+
+input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.radio-group {
+  display: flex;
+  gap: 20px;
+}
+
+.radio-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  cursor: pointer;
+
+  input[type="radio"] { width: 16px; height: 16px; cursor: pointer; }
+}
+
+.field-error {
+  font-size: 0.75rem;
+  color: #f87171;
+  margin: 0;
+}
+
+.feedback-error   { color: #f87171; font-size: 0.875rem; margin: 0; }
+.feedback-success { color: #34d399; font-size: 0.875rem; margin: 0; }
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+
+  .btn-secondary {
+    flex: 1;
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 8px;
+    padding: 10px;
+    font-size: 0.9rem;
+    cursor: pointer;
+
+    &:hover { background: rgba(255, 255, 255, 0.15); }
+  }
+
+  .btn-primary {
+    flex: 2;
+    background: #10b981;
+    color: #000;
+    border: none;
+    border-radius: 8px;
+    padding: 10px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
+    &:hover:not(:disabled) { background: #059669; }
+  }
+}
+
+.state-loading {
+  padding: 48px 0;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.spinner-sm {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(0, 0, 0, 0.3);
+  border-top-color: #000;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/src/app/pages/admin/announcements/edit/admin-announcement-edit.component.ts
+++ b/src/app/pages/admin/announcements/edit/admin-announcement-edit.component.ts
@@ -1,0 +1,239 @@
+import { Component, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { ActivatedRoute, Router } from '@angular/router'
+import {
+  ReactiveFormsModule,
+  FormBuilder,
+  FormGroup,
+  Validators,
+  AbstractControl,
+} from '@angular/forms'
+import { AnnouncementsService } from 'src/app/services/announcements.service'
+import { LeagueAnnouncement, AnnouncementCreateInput } from 'src/app/models/league-announcement.model'
+import { AdminFieldValue } from 'src/app/models/admin-field-value.model'
+
+/**
+ * Admin announcement edit / create form.
+ *
+ * Routes:
+ *   /admin/announcements/new  — create mode (no :id)
+ *   /admin/announcements/:id  — edit mode (diff-on-save)
+ *
+ * Expiry 3-state:
+ *   hasExpiry = false → send expires_at: null (clear any existing expiry)
+ *   hasExpiry = true  → send expires_at: ISO string of the chosen datetime
+ *   (update only sends the field if it changed vs the original)
+ */
+@Component({
+  selector: 'app-admin-announcement-edit',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './admin-announcement-edit.component.html',
+  styleUrls: ['./admin-announcement-edit.component.scss'],
+})
+export class AdminAnnouncementEditComponent implements OnInit {
+  form!: FormGroup
+  isNew = true
+  isLoading = false
+  isSaving = false
+  error: string | null = null
+  successMessage: string | null = null
+
+  private announcementId: string | null = null
+  private original: LeagueAnnouncement | null = null
+
+  constructor(
+    private fb: FormBuilder,
+    private route: ActivatedRoute,
+    private router: Router,
+    private announcementsService: AnnouncementsService,
+  ) {}
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id')
+    this.isNew = !id || id === 'new'
+    this.announcementId = this.isNew ? null : id
+
+    this.buildForm()
+
+    if (!this.isNew && this.announcementId) {
+      this.loadExisting(this.announcementId)
+    }
+  }
+
+  private buildForm(): void {
+    this.form = this.fb.group({
+      title: ['', [Validators.required, Validators.maxLength(200)]],
+      body: ['', [Validators.required]],
+      priority: ['info', Validators.required],
+      isActive: [true],
+      displayOrder: [0, [Validators.required, Validators.min(0)]],
+      hasExpiry: [false],
+      expiresAt: [''],
+    })
+
+    // When hasExpiry is toggled off, clear expiresAt so it doesn't block form validity.
+    this.form.get('hasExpiry')?.valueChanges.subscribe((hasExpiry: boolean) => {
+      const expiresAtCtrl = this.form.get('expiresAt')!
+      if (hasExpiry) {
+        expiresAtCtrl.setValidators([Validators.required])
+      } else {
+        expiresAtCtrl.clearValidators()
+        expiresAtCtrl.setValue('')
+      }
+      expiresAtCtrl.updateValueAndValidity()
+    })
+  }
+
+  private loadExisting(id: string): void {
+    this.isLoading = true
+    this.announcementsService.getById(id).subscribe({
+      next: (row) => {
+        this.isLoading = false
+        if (!row) {
+          this.error = 'Announcement not found.'
+          return
+        }
+        this.original = row
+        const hasExpiry = !!row.expiresAt
+        // datetime-local input requires "YYYY-MM-DDTHH:mm" format
+        const expiresAtValue = row.expiresAt
+          ? new Date(row.expiresAt).toISOString().slice(0, 16)
+          : ''
+
+        this.form.patchValue({
+          title: row.title,
+          body: row.body,
+          priority: row.priority,
+          isActive: row.isActive,
+          displayOrder: row.displayOrder,
+          hasExpiry,
+          expiresAt: expiresAtValue,
+        })
+
+        // Trigger the hasExpiry change handler to set validators correctly.
+        if (hasExpiry) {
+          this.form.get('expiresAt')?.setValidators([Validators.required])
+          this.form.get('expiresAt')?.updateValueAndValidity()
+        }
+      },
+      error: (err: unknown) => {
+        this.isLoading = false
+        this.error = err instanceof Error ? err.message : 'Failed to load announcement.'
+      },
+    })
+  }
+
+  get hasExpiryCtrl(): AbstractControl {
+    return this.form.get('hasExpiry')!
+  }
+
+  submit(): void {
+    if (this.form.invalid || this.isSaving) return
+    this.error = null
+    this.successMessage = null
+    this.isSaving = true
+
+    const v = this.form.value as {
+      title: string
+      body: string
+      priority: 'critical' | 'info'
+      isActive: boolean
+      displayOrder: number
+      hasExpiry: boolean
+      expiresAt: string
+    }
+
+    const expiresAtIso = v.hasExpiry && v.expiresAt
+      ? new Date(v.expiresAt).toISOString()
+      : null
+
+    if (this.isNew) {
+      const input: AnnouncementCreateInput = {
+        title: v.title.trim(),
+        body: v.body.trim(),
+        priority: v.priority,
+        is_active: v.isActive,
+        display_order: v.displayOrder,
+        expires_at: expiresAtIso ?? undefined,
+      }
+      this.announcementsService.create(input).subscribe({
+        next: (row) => {
+          this.isSaving = false
+          this.router.navigate(['/admin/announcements', row.id])
+        },
+        error: (err: unknown) => {
+          this.isSaving = false
+          this.error = err instanceof Error ? err.message : 'Create failed.'
+        },
+      })
+    } else {
+      const fields = this.buildDiff(v, expiresAtIso)
+      if (Object.keys(fields).length === 0) {
+        this.isSaving = false
+        this.successMessage = 'No changes detected.'
+        return
+      }
+      this.announcementsService.update(this.announcementId!, fields).subscribe({
+        next: (row) => {
+          this.isSaving = false
+          this.original = row
+          this.successMessage = 'Saved.'
+        },
+        error: (err: unknown) => {
+          this.isSaving = false
+          this.error = err instanceof Error ? err.message : 'Update failed.'
+        },
+      })
+    }
+  }
+
+  /**
+   * Build a diff map by comparing the form values against the original row.
+   * Only sends fields that actually changed (mirrors iOS diff-and-send).
+   */
+  private buildDiff(
+    v: {
+      title: string
+      body: string
+      priority: 'critical' | 'info'
+      isActive: boolean
+      displayOrder: number
+      hasExpiry: boolean
+      expiresAt: string
+    },
+    expiresAtIso: string | null,
+  ): Record<string, AdminFieldValue> {
+    const orig = this.original!
+    const diff: Record<string, AdminFieldValue> = {}
+
+    if (v.title.trim() !== orig.title)      diff['title']         = { kind: 'string', value: v.title.trim() }
+    if (v.body.trim()  !== orig.body)       diff['body']          = { kind: 'string', value: v.body.trim() }
+    if (v.priority !== orig.priority)       diff['priority']      = { kind: 'string', value: v.priority }
+    if (v.isActive !== orig.isActive)       diff['is_active']     = { kind: 'bool',   value: v.isActive }
+    if (v.displayOrder !== orig.displayOrder) diff['display_order'] = { kind: 'int',  value: v.displayOrder }
+
+    // Expiry 3-state:
+    //   was null → now has value:  send the new ISO string
+    //   had value → now cleared:   send null
+    //   had value → new value:     send new ISO string if changed
+    const origExpiry = orig.expiresAt
+      ? new Date(orig.expiresAt).toISOString().slice(0, 19) + 'Z'
+      : null
+    const newExpiry = expiresAtIso
+      ? new Date(expiresAtIso).toISOString().slice(0, 19) + 'Z'
+      : null
+
+    if (origExpiry !== newExpiry) {
+      diff['expires_at'] = newExpiry
+        ? { kind: 'string', value: newExpiry }
+        : { kind: 'null' }
+    }
+
+    return diff
+  }
+
+  cancel(): void {
+    this.router.navigate(['/admin/announcements'])
+  }
+}

--- a/src/app/pages/admin/announcements/list/admin-announcements-list.component.html
+++ b/src/app/pages/admin/announcements/list/admin-announcements-list.component.html
@@ -1,0 +1,65 @@
+<div class="announcements-list">
+  <div class="list-header">
+    <h2>Announcements</h2>
+    <button class="btn-primary" (click)="navigateNew()">+ New</button>
+  </div>
+
+  <!-- Loading -->
+  <div *ngIf="isLoading" class="state-empty">
+    <p>Loading…</p>
+  </div>
+
+  <!-- Table missing (migration pending) -->
+  <div *ngIf="!isLoading && tableMissing" class="state-empty state-warning">
+    <p class="state-title">Table not provisioned</p>
+    <p class="state-body">The <code>league_announcements</code> table hasn't been created yet. Run the Supabase migration and refresh.</p>
+  </div>
+
+  <!-- Error -->
+  <div *ngIf="!isLoading && error && !tableMissing" class="state-empty state-error">
+    <p>{{ error }}</p>
+    <button class="btn-secondary" (click)="load()">Retry</button>
+  </div>
+
+  <!-- Empty -->
+  <div *ngIf="!isLoading && !tableMissing && !error && rows.length === 0" class="state-empty">
+    <p>No announcements yet.</p>
+    <p class="state-sub">Tap "+ New" to create the first one.</p>
+  </div>
+
+  <!-- List -->
+  <ul *ngIf="!isLoading && !tableMissing && !error && rows.length > 0" class="row-list">
+    <li *ngFor="let row of rows" class="row-item">
+      <button class="row-body" (click)="navigateEdit(row.id)">
+        <div class="row-chips">
+          <span class="chip" [class.chip-critical]="row.priority === 'critical'" [class.chip-info]="row.priority === 'info'">
+            {{ priorityLabel(row.priority) }}
+          </span>
+          <span class="chip" [class.chip-active]="row.isActive" [class.chip-inactive]="!row.isActive">
+            {{ row.isActive ? 'Active' : 'Inactive' }}
+          </span>
+          <span *ngIf="isExpired(row)" class="chip chip-expired">Expired</span>
+          <span *ngIf="row.expiresAt && !isExpired(row)" class="chip chip-expiry">{{ expiryLabel(row) }}</span>
+        </div>
+        <p class="row-title">{{ row.title }}</p>
+        <p class="row-body-text">{{ row.body }}</p>
+        <p class="row-meta">Order: {{ row.displayOrder }}</p>
+      </button>
+      <button
+        class="btn-delete"
+        [disabled]="pendingDeleteId === row.id"
+        (click)="confirmDelete(row)"
+        title="Delete"
+      >
+        <span *ngIf="pendingDeleteId === row.id" class="spinner-sm"></span>
+        <span *ngIf="pendingDeleteId !== row.id">Delete</span>
+      </button>
+    </li>
+  </ul>
+
+  <app-confirm-dialog
+    [config]="deleteDialogConfig"
+    [visible]="showDeleteDialog"
+    (confirmed)="onDeleteConfirmed($event)"
+  />
+</div>

--- a/src/app/pages/admin/announcements/list/admin-announcements-list.component.scss
+++ b/src/app/pages/admin/announcements/list/admin-announcements-list.component.scss
@@ -1,0 +1,163 @@
+.announcements-list {
+  padding: 24px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+
+  h2 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+}
+
+.state-empty {
+  text-align: center;
+  padding: 48px 16px;
+  color: rgba(255, 255, 255, 0.5);
+
+  &.state-warning { color: #f59e0b; }
+  &.state-error   { color: #ef4444; }
+
+  .state-title { font-weight: 600; margin-bottom: 8px; }
+  .state-body  { font-size: 0.875rem; }
+  .state-sub   { font-size: 0.875rem; margin-top: 4px; }
+}
+
+.row-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.row-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.row-body {
+  flex: 1;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 0;
+}
+
+.row-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.chip {
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-weight: 500;
+
+  &.chip-critical { background: rgba(239, 68, 68, 0.2); color: #f87171; }
+  &.chip-info     { background: rgba(59, 130, 246, 0.2); color: #60a5fa; }
+  &.chip-active   { background: rgba(16, 185, 129, 0.2); color: #34d399; }
+  &.chip-inactive { background: rgba(255, 255, 255, 0.1); color: rgba(255, 255, 255, 0.5); }
+  &.chip-expired  { background: rgba(239, 68, 68, 0.15); color: #f87171; }
+  &.chip-expiry   { background: rgba(245, 158, 11, 0.15); color: #fbbf24; }
+}
+
+.row-title {
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+
+.row-body-text {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin: 0 0 6px;
+  white-space: pre-wrap;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.row-meta {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.4);
+  margin: 0;
+}
+
+.btn-delete {
+  background: rgba(239, 68, 68, 0.15);
+  color: #f87171;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  white-space: nowrap;
+  align-self: flex-start;
+  min-width: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &:hover:not(:disabled) {
+    background: rgba(239, 68, 68, 0.25);
+  }
+}
+
+.btn-primary {
+  background: #10b981;
+  color: #000;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover { background: #059669; }
+}
+
+.btn-secondary {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+  margin-top: 12px;
+}
+
+.spinner-sm {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/src/app/pages/admin/announcements/list/admin-announcements-list.component.ts
+++ b/src/app/pages/admin/announcements/list/admin-announcements-list.component.ts
@@ -1,0 +1,113 @@
+import { Component, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { Router } from '@angular/router'
+import { AnnouncementsService } from 'src/app/services/announcements.service'
+import { LeagueAnnouncement } from 'src/app/models/league-announcement.model'
+import {
+  ConfirmDialogComponent,
+  ConfirmDialogConfig,
+} from 'src/app/components/confirm-dialog/confirm-dialog.component'
+
+@Component({
+  selector: 'app-admin-announcements-list',
+  standalone: true,
+  imports: [CommonModule, ConfirmDialogComponent],
+  templateUrl: './admin-announcements-list.component.html',
+  styleUrls: ['./admin-announcements-list.component.scss'],
+})
+export class AdminAnnouncementsListComponent implements OnInit {
+  rows: LeagueAnnouncement[] = []
+  isLoading = false
+  tableMissing = false
+  error: string | null = null
+
+  /** ID of the row currently being deleted (for per-row spinner). */
+  pendingDeleteId: string | null = null
+
+  /** Controls the confirm dialog visibility. */
+  showDeleteDialog = false
+  deleteDialogConfig: ConfirmDialogConfig = {
+    title: 'Delete Announcement',
+    message: '',
+    confirmLabel: 'Delete',
+    destructive: true,
+  }
+  private _pendingDeleteTarget: LeagueAnnouncement | null = null
+
+  constructor(
+    private announcementsService: AnnouncementsService,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.load()
+  }
+
+  load(): void {
+    this.isLoading = true
+    this.error = null
+    this.announcementsService.listAdmin().subscribe({
+      next: ({ rows, tableMissing }) => {
+        this.rows = rows
+        this.tableMissing = tableMissing
+        this.isLoading = false
+      },
+      error: (err: unknown) => {
+        this.error = err instanceof Error ? err.message : 'Failed to load announcements.'
+        this.isLoading = false
+      },
+    })
+  }
+
+  navigateNew(): void {
+    this.router.navigate(['/admin/announcements/new'])
+  }
+
+  navigateEdit(id: string): void {
+    this.router.navigate(['/admin/announcements', id])
+  }
+
+  confirmDelete(row: LeagueAnnouncement): void {
+    this._pendingDeleteTarget = row
+    this.deleteDialogConfig = {
+      ...this.deleteDialogConfig,
+      message: `Delete "${row.title}"? This will set it inactive on the backend. The row stays in the database.`,
+    }
+    this.showDeleteDialog = true
+  }
+
+  onDeleteConfirmed(confirmed: boolean): void {
+    this.showDeleteDialog = false
+    if (!confirmed || !this._pendingDeleteTarget) return
+    const target = this._pendingDeleteTarget
+    this._pendingDeleteTarget = null
+    this.pendingDeleteId = target.id
+    this.announcementsService.softDelete(target.id).subscribe({
+      next: () => {
+        this.pendingDeleteId = null
+        this.load()
+      },
+      error: (err: unknown) => {
+        this.pendingDeleteId = null
+        this.error = err instanceof Error ? err.message : 'Delete failed.'
+      },
+    })
+  }
+
+  priorityLabel(priority: 'critical' | 'info'): string {
+    return priority === 'critical' ? 'Critical' : 'Info'
+  }
+
+  expiryLabel(row: LeagueAnnouncement): string {
+    if (!row.expiresAt) return ''
+    const d = new Date(row.expiresAt)
+    const now = new Date()
+    if (d < now) return 'Expired'
+    return `Expires ${d.toLocaleDateString()}`
+  }
+
+  isExpired(row: LeagueAnnouncement): boolean {
+    if (!row.expiresAt) return false
+    return new Date(row.expiresAt) < new Date()
+  }
+}

--- a/src/app/pages/admin/audit/detail/admin-audit-detail.component.html
+++ b/src/app/pages/admin/audit/detail/admin-audit-detail.component.html
@@ -1,0 +1,84 @@
+<div class="audit-detail">
+  <div class="detail-header">
+    <button class="btn-back" (click)="back()">← Back</button>
+    <h2>Audit Entry</h2>
+  </div>
+
+  <div *ngIf="isLoading" class="state-loading"><p>Loading…</p></div>
+
+  <div *ngIf="!isLoading && error" class="state-loading state-error">
+    <p>{{ error }}</p>
+    <button class="btn-secondary" (click)="back()">Back</button>
+  </div>
+
+  <div *ngIf="!isLoading && notFound && !error" class="state-loading">
+    <p>Entry not found.</p>
+    <button class="btn-secondary" (click)="back()">Back</button>
+  </div>
+
+  <ng-container *ngIf="!isLoading && !notFound && entry">
+    <!-- Header card -->
+    <div class="header-card">
+      <div class="header-action">{{ actionDisplay(entry.action) }}</div>
+      <div class="header-meta">
+        <span class="meta-label">Actor</span>
+        <span class="meta-value">{{ entry.actorUserId }}</span>
+      </div>
+      <div class="header-meta" *ngIf="entry.targetTable">
+        <span class="meta-label">Table</span>
+        <span class="meta-value">{{ entry.targetTable }}</span>
+      </div>
+      <div class="header-meta" *ngIf="entry.targetId">
+        <span class="meta-label">Target ID</span>
+        <span class="meta-value mono">{{ entry.targetId }}</span>
+      </div>
+      <div class="header-meta">
+        <span class="meta-label">Time</span>
+        <span class="meta-value">{{ formatDate(entry.createdAt) }}</span>
+      </div>
+      <div class="header-meta">
+        <span class="meta-label">Entry ID</span>
+        <span class="meta-value mono">{{ entry.id }}</span>
+      </div>
+    </div>
+
+    <!-- Before block -->
+    <div class="json-block" *ngIf="entry.before !== null">
+      <button class="block-toggle" (click)="toggleBlock('before')">
+        <span class="block-label">Before</span>
+        <span class="block-caret">{{ collapsed.before ? '▸' : '▾' }}</span>
+      </button>
+      <pre *ngIf="!collapsed.before" class="json-pre">{{ prettyJson(entry.before) }}</pre>
+    </div>
+    <div class="json-block json-block--absent" *ngIf="entry.before === null">
+      <span class="block-label">Before</span>
+      <span class="absent-label">none</span>
+    </div>
+
+    <!-- After block -->
+    <div class="json-block" *ngIf="entry.after !== null">
+      <button class="block-toggle" (click)="toggleBlock('after')">
+        <span class="block-label">After</span>
+        <span class="block-caret">{{ collapsed.after ? '▸' : '▾' }}</span>
+      </button>
+      <pre *ngIf="!collapsed.after" class="json-pre">{{ prettyJson(entry.after) }}</pre>
+    </div>
+    <div class="json-block json-block--absent" *ngIf="entry.after === null">
+      <span class="block-label">After</span>
+      <span class="absent-label">none</span>
+    </div>
+
+    <!-- Metadata block -->
+    <div class="json-block" *ngIf="entry.metadata !== null">
+      <button class="block-toggle" (click)="toggleBlock('metadata')">
+        <span class="block-label">Metadata</span>
+        <span class="block-caret">{{ collapsed.metadata ? '▸' : '▾' }}</span>
+      </button>
+      <pre *ngIf="!collapsed.metadata" class="json-pre">{{ prettyJson(entry.metadata) }}</pre>
+    </div>
+    <div class="json-block json-block--absent" *ngIf="entry.metadata === null">
+      <span class="block-label">Metadata</span>
+      <span class="absent-label">none</span>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/pages/admin/audit/detail/admin-audit-detail.component.scss
+++ b/src/app/pages/admin/audit/detail/admin-audit-detail.component.scss
@@ -1,0 +1,123 @@
+.audit-detail {
+  padding: 24px;
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 28px;
+
+  h2 { margin: 0; font-size: 1.4rem; font-weight: 600; }
+}
+
+.btn-back {
+  background: none;
+  border: none;
+  color: #10b981;
+  cursor: pointer;
+  font-size: 0.95rem;
+  padding: 0;
+  &:hover { text-decoration: underline; }
+}
+
+.state-loading {
+  padding: 48px 0;
+  text-align: center;
+  color: rgba(255,255,255,0.5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  &.state-error { color: #f87171; }
+}
+
+.btn-secondary {
+  background: rgba(255,255,255,0.1);
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.header-card {
+  background: rgba(255,255,255,0.05);
+  border-radius: 14px;
+  padding: 20px;
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.header-action {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.header-meta {
+  display: flex;
+  gap: 12px;
+  font-size: 0.85rem;
+}
+.meta-label { color: rgba(255,255,255,0.45); min-width: 80px; }
+.meta-value { color: rgba(255,255,255,0.85); word-break: break-all; &.mono { font-family: monospace; } }
+
+.json-block {
+  background: rgba(255,255,255,0.04);
+  border-radius: 10px;
+  margin-bottom: 12px;
+  overflow: hidden;
+
+  &.json-block--absent {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+  }
+}
+
+.block-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.9rem;
+  &:hover { background: rgba(255,255,255,0.04); }
+}
+
+.block-label {
+  font-weight: 600;
+  color: rgba(255,255,255,0.8);
+}
+
+.block-caret {
+  color: rgba(255,255,255,0.4);
+  font-size: 0.8rem;
+}
+
+.absent-label {
+  font-size: 0.8rem;
+  color: rgba(255,255,255,0.3);
+  font-style: italic;
+}
+
+.json-pre {
+  margin: 0;
+  padding: 12px 16px 16px;
+  font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  color: rgba(255,255,255,0.75);
+  overflow-x: auto;
+  white-space: pre;
+}

--- a/src/app/pages/admin/audit/detail/admin-audit-detail.component.ts
+++ b/src/app/pages/admin/audit/detail/admin-audit-detail.component.ts
@@ -1,0 +1,99 @@
+import { Component, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { ActivatedRoute, Router } from '@angular/router'
+import { AuditService } from 'src/app/services/audit.service'
+import { AuditEntry, auditActionDisplay } from 'src/app/models/audit-entry.model'
+
+/**
+ * Admin Audit detail — 3 collapsible JSON blocks: Before / After / Metadata.
+ *
+ * Resolution strategy (mirrors iOS: no separate detail endpoint):
+ *   1. Try AuditService.getFromCache(id).
+ *   2. If cache is empty, fire list(null) to seed the first page and retry.
+ *   3. If still not found → "entry not found" empty state.
+ */
+@Component({
+  selector: 'app-admin-audit-detail',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './admin-audit-detail.component.html',
+  styleUrls: ['./admin-audit-detail.component.scss'],
+})
+export class AdminAuditDetailComponent implements OnInit {
+  entry: AuditEntry | null = null
+  isLoading = false
+  error: string | null = null
+  notFound = false
+
+  /** Collapse state for each JSON block. */
+  collapsed: Record<'before' | 'after' | 'metadata', boolean> = {
+    before: false,
+    after: false,
+    metadata: true,
+  }
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private auditService: AuditService,
+  ) {}
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id')
+    if (!id) {
+      this.notFound = true
+      return
+    }
+    this.resolve(id)
+  }
+
+  private resolve(id: string): void {
+    const cached = this.auditService.getFromCache(id)
+    if (cached) {
+      this.entry = cached
+      return
+    }
+    // Cache is empty (direct navigation / page refresh) — load first page.
+    this.isLoading = true
+    this.auditService.list(null).subscribe({
+      next: () => {
+        this.isLoading = false
+        const found = this.auditService.getFromCache(id)
+        if (found) {
+          this.entry = found
+        } else {
+          this.notFound = true
+        }
+      },
+      error: (err: unknown) => {
+        this.isLoading = false
+        this.error = err instanceof Error ? err.message : 'Failed to load audit entry.'
+      },
+    })
+  }
+
+  toggleBlock(block: 'before' | 'after' | 'metadata'): void {
+    this.collapsed[block] = !this.collapsed[block]
+  }
+
+  prettyJson(value: unknown): string {
+    if (value === null || value === undefined) return 'null'
+    try {
+      return JSON.stringify(value, null, 2)
+    } catch {
+      return String(value)
+    }
+  }
+
+  actionDisplay(action: string): string {
+    return auditActionDisplay(action)
+  }
+
+  formatDate(iso: string): string {
+    return new Date(iso).toLocaleString()
+  }
+
+  back(): void {
+    this.router.navigate(['/admin/audit'])
+  }
+}

--- a/src/app/pages/admin/audit/feed/admin-audit-feed.component.html
+++ b/src/app/pages/admin/audit/feed/admin-audit-feed.component.html
@@ -1,0 +1,49 @@
+<div class="audit-feed">
+  <div class="feed-header">
+    <h2>Audit Log</h2>
+  </div>
+
+  <!-- Loading -->
+  <div *ngIf="isLoading" class="state-empty">
+    <p>Loading…</p>
+  </div>
+
+  <!-- Table missing -->
+  <div *ngIf="!isLoading && tableMissing" class="state-empty state-warning">
+    <p class="state-title">Audit table not provisioned</p>
+    <p class="state-body">The <code>admin_audit</code> table hasn't been created yet. Run the Supabase migration and refresh.</p>
+  </div>
+
+  <!-- Error -->
+  <div *ngIf="!isLoading && error && !tableMissing" class="state-empty state-error">
+    <p>{{ error }}</p>
+    <button class="btn-secondary" (click)="retry()">Retry</button>
+  </div>
+
+  <!-- Empty -->
+  <div *ngIf="!isLoading && !tableMissing && !error && rows.length === 0" class="state-empty">
+    <p>No audit entries yet.</p>
+    <p class="state-sub">Admin actions will appear here once any mutation is made.</p>
+  </div>
+
+  <!-- Feed -->
+  <ul *ngIf="!isLoading && !tableMissing && !error && rows.length > 0" class="row-list">
+    <li *ngFor="let row of rows" class="row-item" (click)="navigateDetail(row)">
+      <div class="row-action">{{ actionDisplay(row) }}</div>
+      <div class="row-meta">
+        <span class="row-actor">{{ row.actorUserId }}</span>
+        <span class="row-target" *ngIf="row.targetTable">· {{ row.targetTable }}</span>
+        <span class="row-target" *ngIf="row.targetId">{{ row.targetId }}</span>
+      </div>
+      <div class="row-date">{{ formatDate(row.createdAt) }}</div>
+    </li>
+  </ul>
+
+  <!-- Infinite scroll sentinel -->
+  <div #sentinel class="sentinel" *ngIf="hasMore"></div>
+
+  <!-- Load-more spinner -->
+  <div *ngIf="isLoadingMore" class="load-more-spinner">
+    <span class="spinner"></span>
+  </div>
+</div>

--- a/src/app/pages/admin/audit/feed/admin-audit-feed.component.scss
+++ b/src/app/pages/admin/audit/feed/admin-audit-feed.component.scss
@@ -1,0 +1,95 @@
+.audit-feed {
+  padding: 24px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.feed-header {
+  margin-bottom: 24px;
+  h2 { margin: 0; font-size: 1.5rem; font-weight: 600; }
+}
+
+.state-empty {
+  text-align: center;
+  padding: 48px 16px;
+  color: rgba(255,255,255,0.5);
+
+  &.state-warning { color: #f59e0b; }
+  &.state-error   { color: #ef4444; }
+
+  .state-title { font-weight: 600; margin-bottom: 8px; }
+  .state-body  { font-size: 0.875rem; }
+  .state-sub   { font-size: 0.875rem; margin-top: 4px; }
+}
+
+.btn-secondary {
+  margin-top: 12px;
+  background: rgba(255,255,255,0.1);
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.row-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.row-item {
+  background: rgba(255,255,255,0.05);
+  border-radius: 12px;
+  padding: 14px 16px;
+  cursor: pointer;
+  transition: background 0.15s;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  &:hover { background: rgba(255,255,255,0.09); }
+}
+
+.row-action {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.row-meta {
+  font-size: 0.8rem;
+  color: rgba(255,255,255,0.5);
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.row-date {
+  font-size: 0.75rem;
+  color: rgba(255,255,255,0.35);
+}
+
+.sentinel {
+  height: 1px;
+  margin-top: 20px;
+}
+
+.load-more-spinner {
+  display: flex;
+  justify-content: center;
+  padding: 20px;
+}
+
+.spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid rgba(255,255,255,0.2);
+  border-top-color: #10b981;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }

--- a/src/app/pages/admin/audit/feed/admin-audit-feed.component.ts
+++ b/src/app/pages/admin/audit/feed/admin-audit-feed.component.ts
@@ -1,0 +1,117 @@
+import { Component, OnInit, OnDestroy, AfterViewInit, ElementRef, ViewChild } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { Router } from '@angular/router'
+import { AuditService } from 'src/app/services/audit.service'
+import { AuditEntry, auditActionDisplay } from 'src/app/models/audit-entry.model'
+
+/**
+ * Admin Audit feed — cursor-paginated with IntersectionObserver infinite scroll.
+ * Mirrors iOS AuditFeedView.swift.
+ *
+ * Empty-state branches:
+ *   tableMissing → migration message
+ *   empty        → "no entries yet"
+ *   error        → retry
+ */
+@Component({
+  selector: 'app-admin-audit-feed',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './admin-audit-feed.component.html',
+  styleUrls: ['./admin-audit-feed.component.scss'],
+})
+export class AdminAuditFeedComponent implements OnInit, OnDestroy, AfterViewInit {
+  @ViewChild('sentinel') sentinelRef!: ElementRef<HTMLElement>
+
+  rows: AuditEntry[] = []
+  isLoading = false
+  isLoadingMore = false
+  error: string | null = null
+  tableMissing = false
+  nextCursor: string | null = null
+  hasMore = false
+
+  private observer: IntersectionObserver | null = null
+
+  constructor(
+    private auditService: AuditService,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.auditService.clearCache()
+    this.load(null)
+  }
+
+  ngAfterViewInit(): void {
+    this.observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && this.hasMore && !this.isLoadingMore) {
+          this.loadMore()
+        }
+      },
+      { rootMargin: '200px' },
+    )
+    if (this.sentinelRef?.nativeElement) {
+      this.observer.observe(this.sentinelRef.nativeElement)
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.observer?.disconnect()
+  }
+
+  load(cursor: string | null): void {
+    this.isLoading = true
+    this.error = null
+    this.auditService.list(cursor).subscribe({
+      next: ({ rows, nextCursor, tableMissing }) => {
+        this.rows = rows
+        this.nextCursor = nextCursor
+        this.hasMore = !!nextCursor
+        this.tableMissing = tableMissing
+        this.isLoading = false
+      },
+      error: (err: unknown) => {
+        this.error = err instanceof Error ? err.message : 'Failed to load audit log.'
+        this.isLoading = false
+      },
+    })
+  }
+
+  loadMore(): void {
+    if (!this.nextCursor || this.isLoadingMore) return
+    this.isLoadingMore = true
+    this.auditService.list(this.nextCursor).subscribe({
+      next: ({ rows, nextCursor }) => {
+        this.rows = [...this.rows, ...rows]
+        this.nextCursor = nextCursor
+        this.hasMore = !!nextCursor
+        this.isLoadingMore = false
+      },
+      error: () => {
+        this.isLoadingMore = false
+      },
+    })
+  }
+
+  retry(): void {
+    this.auditService.clearCache()
+    this.rows = []
+    this.nextCursor = null
+    this.hasMore = false
+    this.load(null)
+  }
+
+  navigateDetail(entry: AuditEntry): void {
+    this.router.navigate(['/admin/audit', entry.id])
+  }
+
+  actionDisplay(entry: AuditEntry): string {
+    return auditActionDisplay(entry.action)
+  }
+
+  formatDate(iso: string): string {
+    return new Date(iso).toLocaleString()
+  }
+}

--- a/src/app/pages/admin/cron-settings/admin-cron-settings.component.html
+++ b/src/app/pages/admin/cron-settings/admin-cron-settings.component.html
@@ -1,0 +1,77 @@
+<div class="cron-settings">
+  <!-- Test-mode sticky banner -->
+  <div *ngIf="anyTestModeActive" class="test-mode-banner">
+    Test mode active — deliveries restricted to admin only
+  </div>
+
+  <div class="page-header">
+    <h2>Cron Settings</h2>
+  </div>
+
+  <!-- Loading -->
+  <div *ngIf="isLoading" class="state-empty"><p>Loading…</p></div>
+
+  <!-- Table missing -->
+  <div *ngIf="!isLoading && tableMissing" class="state-empty state-warning">
+    <p class="state-title">Cron settings table not provisioned</p>
+    <p class="state-body">The <code>admin_cron_settings</code> table hasn't been created yet. Run the Supabase migration and refresh.</p>
+  </div>
+
+  <!-- Error -->
+  <div *ngIf="!isLoading && error && !tableMissing" class="state-empty state-error">
+    <p>{{ error }}</p>
+    <button class="btn-secondary" (click)="load()">Retry</button>
+  </div>
+
+  <!-- Empty -->
+  <div *ngIf="!isLoading && !tableMissing && !error && rows.length === 0" class="state-empty">
+    <p>No cron settings found.</p>
+  </div>
+
+  <!-- Rows -->
+  <ul *ngIf="!isLoading && !tableMissing && !error && rows.length > 0" class="row-list">
+    <li *ngFor="let row of rows" class="row-item">
+      <div class="row-info">
+        <span class="row-title">{{ displayTitle(row) }}</span>
+        <span class="row-key">{{ row.cronKey }}</span>
+      </div>
+      <div class="row-controls">
+        <!-- Pending spinner -->
+        <span *ngIf="isPending(row.cronKey)" class="spinner-sm"></span>
+
+        <ng-container *ngIf="!isPending(row.cronKey)">
+          <!-- Enabled toggle -->
+          <div class="toggle-group">
+            <span class="toggle-label" [class.toggle-label--off]="!row.enabled">Enabled</span>
+            <button
+              class="toggle"
+              [class.toggle--on]="row.enabled"
+              [class.toggle--off]="!row.enabled"
+              (click)="toggleEnabled(row)"
+              title="{{ row.enabled ? 'Disable' : 'Enable' }} cron"
+            ></button>
+          </div>
+
+          <!-- Test mode toggle (disabled when cron is off) -->
+          <div class="toggle-group" [class.toggle-group--disabled]="!row.enabled">
+            <span class="toggle-label" [class.toggle-label--off]="!row.testMode">Test</span>
+            <button
+              class="toggle"
+              [class.toggle--on]="row.testMode && row.enabled"
+              [class.toggle--off]="!row.testMode || !row.enabled"
+              [disabled]="!row.enabled"
+              (click)="toggleTestMode(row)"
+              title="Toggle test mode"
+            ></button>
+          </div>
+        </ng-container>
+      </div>
+    </li>
+  </ul>
+
+  <app-confirm-dialog
+    [config]="dialogConfig"
+    [visible]="showDialog"
+    (confirmed)="onDialogConfirmed($event)"
+  />
+</div>

--- a/src/app/pages/admin/cron-settings/admin-cron-settings.component.scss
+++ b/src/app/pages/admin/cron-settings/admin-cron-settings.component.scss
@@ -1,0 +1,155 @@
+.cron-settings {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.test-mode-banner {
+  background: rgba(245, 158, 11, 0.15);
+  border-bottom: 1px solid rgba(245, 158, 11, 0.3);
+  color: #fbbf24;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-align: center;
+  padding: 10px 16px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.page-header {
+  padding: 24px 24px 8px;
+  h2 { margin: 0; font-size: 1.5rem; font-weight: 600; }
+}
+
+.state-empty {
+  text-align: center;
+  padding: 48px 16px;
+  color: rgba(255,255,255,0.5);
+
+  &.state-warning { color: #f59e0b; }
+  &.state-error   { color: #ef4444; }
+
+  .state-title { font-weight: 600; margin-bottom: 8px; }
+  .state-body  { font-size: 0.875rem; }
+}
+
+.btn-secondary {
+  margin-top: 12px;
+  background: rgba(255,255,255,0.1);
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.row-list {
+  list-style: none;
+  padding: 16px 24px;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.row-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(255,255,255,0.05);
+  border-radius: 12px;
+  padding: 16px;
+  gap: 16px;
+}
+
+.row-info {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1;
+  min-width: 0;
+}
+
+.row-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row-key {
+  font-size: 0.75rem;
+  color: rgba(255,255,255,0.4);
+  font-family: monospace;
+}
+
+.row-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-shrink: 0;
+}
+
+.toggle-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+
+  &.toggle-group--disabled {
+    opacity: 0.4;
+    pointer-events: none;
+  }
+}
+
+.toggle-label {
+  font-size: 0.7rem;
+  color: rgba(255,255,255,0.6);
+  &.toggle-label--off { color: rgba(255,255,255,0.3); }
+}
+
+.toggle {
+  width: 44px;
+  height: 24px;
+  border-radius: 9999px;
+  border: none;
+  cursor: pointer;
+  position: relative;
+  transition: background 0.2s;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 3px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #fff;
+    transition: left 0.2s;
+  }
+
+  &.toggle--on {
+    background: #10b981;
+    &::after { left: 23px; }
+  }
+
+  &.toggle--off {
+    background: rgba(255,255,255,0.2);
+    &::after { left: 3px; }
+  }
+
+  &:disabled { cursor: not-allowed; }
+}
+
+.spinner-sm {
+  width: 20px;
+  height: 20px;
+  border: 2px solid rgba(255,255,255,0.2);
+  border-top-color: #10b981;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }

--- a/src/app/pages/admin/cron-settings/admin-cron-settings.component.ts
+++ b/src/app/pages/admin/cron-settings/admin-cron-settings.component.ts
@@ -1,0 +1,153 @@
+import { Component, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { CronService } from 'src/app/services/cron.service'
+import { CronSetting, cronDisplayTitle } from 'src/app/models/cron-setting.model'
+import {
+  ConfirmDialogComponent,
+  ConfirmDialogConfig,
+} from 'src/app/components/confirm-dialog/confirm-dialog.component'
+
+/**
+ * Admin Cron Settings — per-row enabled/test-mode toggle pair.
+ *
+ * "Test mode active" gold sticky banner when any row has testMode=true.
+ * Per-row pending spinner while an in-flight toggle call resolves.
+ * ConfirmDialog before flipping `enabled` to false (kill-switch).
+ *
+ * Mirrors iOS CronSettingsView.swift + CronSettingsStore.swift.
+ */
+@Component({
+  selector: 'app-admin-cron-settings',
+  standalone: true,
+  imports: [CommonModule, ConfirmDialogComponent],
+  templateUrl: './admin-cron-settings.component.html',
+  styleUrls: ['./admin-cron-settings.component.scss'],
+})
+export class AdminCronSettingsComponent implements OnInit {
+  rows: CronSetting[] = []
+  isLoading = false
+  tableMissing = false
+  error: string | null = null
+
+  /** Per-row in-flight tracker. cronKey → true while request is pending. */
+  pendingKeys: Record<string, boolean> = {}
+
+  /** Confirm dialog for toggling enabled off. */
+  showDialog = false
+  dialogConfig: ConfirmDialogConfig = {
+    title: 'Disable Cron',
+    message: '',
+    confirmLabel: 'Disable',
+    destructive: true,
+  }
+  private _pendingToggle: { cronKey: string } | null = null
+
+  constructor(private cronService: CronService) {}
+
+  ngOnInit(): void {
+    this.load()
+  }
+
+  load(): void {
+    this.isLoading = true
+    this.error = null
+    this.cronService.list().subscribe({
+      next: ({ rows, tableMissing }) => {
+        this.rows = rows
+        this.tableMissing = tableMissing
+        this.isLoading = false
+      },
+      error: (err: unknown) => {
+        this.error = err instanceof Error ? err.message : 'Failed to load cron settings.'
+        this.isLoading = false
+      },
+    })
+  }
+
+  get anyTestModeActive(): boolean {
+    return this.rows.some((r) => r.testMode)
+  }
+
+  displayTitle(row: CronSetting): string {
+    return cronDisplayTitle(row)
+  }
+
+  toggleEnabled(row: CronSetting): void {
+    const newEnabled = !row.enabled
+    if (!newEnabled) {
+      // Disabling a cron is destructive — confirm first.
+      this._pendingToggle = { cronKey: row.cronKey }
+      this.dialogConfig = {
+        ...this.dialogConfig,
+        message: `Disable "${this.displayTitle(row)}"? This will stop the cron from firing in production.`,
+      }
+      this.showDialog = true
+      return
+    }
+    this.applyEnabledToggle(row.cronKey, newEnabled)
+  }
+
+  onDialogConfirmed(confirmed: boolean): void {
+    this.showDialog = false
+    if (!confirmed || !this._pendingToggle) return
+    const { cronKey } = this._pendingToggle
+    this._pendingToggle = null
+    const row = this.rows.find((r) => r.cronKey === cronKey)
+    if (!row) return
+    this.applyEnabledToggle(cronKey, false)
+  }
+
+  private applyEnabledToggle(cronKey: string, enabled: boolean): void {
+    this.pendingKeys[cronKey] = true
+    // Optimistic update.
+    this.rows = this.rows.map((r) =>
+      r.cronKey === cronKey ? { ...r, enabled } : r,
+    )
+    this.cronService.setEnabled(cronKey, enabled).subscribe({
+      next: (patch) => {
+        this.pendingKeys[cronKey] = false
+        // Reconcile with server echo.
+        this.rows = this.rows.map((r) =>
+          r.cronKey === cronKey ? { ...r, ...patch } : r,
+        )
+      },
+      error: () => {
+        this.pendingKeys[cronKey] = false
+        // Revert optimistic update.
+        this.rows = this.rows.map((r) =>
+          r.cronKey === cronKey ? { ...r, enabled: !enabled } : r,
+        )
+      },
+    })
+  }
+
+  toggleTestMode(row: CronSetting): void {
+    if (!row.enabled) return  // test-mode disabled when cron is off (iOS UX rule)
+    const newTestMode = !row.testMode
+    const cronKey = row.cronKey
+    this.pendingKeys[cronKey] = true
+    // Optimistic.
+    this.rows = this.rows.map((r) =>
+      r.cronKey === cronKey ? { ...r, testMode: newTestMode } : r,
+    )
+    this.cronService.setTestMode(cronKey, newTestMode).subscribe({
+      next: (patch) => {
+        this.pendingKeys[cronKey] = false
+        this.rows = this.rows.map((r) =>
+          r.cronKey === cronKey ? { ...r, ...patch } : r,
+        )
+      },
+      error: () => {
+        this.pendingKeys[cronKey] = false
+        // Revert.
+        this.rows = this.rows.map((r) =>
+          r.cronKey === cronKey ? { ...r, testMode: !newTestMode } : r,
+        )
+      },
+    })
+  }
+
+  isPending(cronKey: string): boolean {
+    return !!this.pendingKeys[cronKey]
+  }
+}

--- a/src/app/pages/admin/logs/admin-logs.component.html
+++ b/src/app/pages/admin/logs/admin-logs.component.html
@@ -1,0 +1,13 @@
+<div class="logs-placeholder">
+  <div class="placeholder-card">
+    <div class="terminal-icon">⌨</div>
+    <h3>CloudWatch logs coming soon</h3>
+    <p>Tail logs in the AWS console for now.</p>
+    <a
+      href="https://console.aws.amazon.com/cloudwatch/home#logsV2:log-groups"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="console-link"
+    >Open AWS Console ↗</a>
+  </div>
+</div>

--- a/src/app/pages/admin/logs/admin-logs.component.scss
+++ b/src/app/pages/admin/logs/admin-logs.component.scss
@@ -1,0 +1,43 @@
+.logs-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 24px;
+}
+
+.placeholder-card {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  max-width: 360px;
+}
+
+.terminal-icon {
+  font-size: 3rem;
+  line-height: 1;
+  color: rgba(255,255,255,0.3);
+}
+
+h3 {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin: 0;
+  color: rgba(255,255,255,0.7);
+}
+
+p {
+  font-size: 0.9rem;
+  color: rgba(255,255,255,0.4);
+  margin: 0;
+}
+
+.console-link {
+  font-size: 0.85rem;
+  color: #10b981;
+  text-decoration: none;
+  margin-top: 4px;
+  &:hover { text-decoration: underline; }
+}

--- a/src/app/pages/admin/logs/admin-logs.component.ts
+++ b/src/app/pages/admin/logs/admin-logs.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core'
+import { CommonModule } from '@angular/common'
+
+/**
+ * Admin Logs placeholder.
+ *
+ * Static empty-state card: terminal icon + "CloudWatch logs coming soon".
+ * No fetch logic, no store. Matches D-D deferral from the s7 plan.
+ */
+@Component({
+  selector: 'app-admin-logs',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './admin-logs.component.html',
+  styleUrls: ['./admin-logs.component.scss'],
+})
+export class AdminLogsComponent {}

--- a/src/app/pages/admin/tables/admin-tables-menu.component.html
+++ b/src/app/pages/admin/tables/admin-tables-menu.component.html
@@ -1,0 +1,17 @@
+<div class="tables-menu">
+  <div class="menu-header">
+    <h2>Tables</h2>
+  </div>
+  <div class="tile-grid">
+    <button
+      *ngFor="let tile of tiles"
+      class="tile"
+      [title]="tile.tooltip || ''"
+      (click)="navigate(tile)"
+    >
+      <span class="tile-label">{{ tile.label }}</span>
+      <span class="tile-subtitle">{{ tile.subtitle }}</span>
+      <span *ngIf="tile.tooltip" class="tile-badge">AI Review ↗</span>
+    </button>
+  </div>
+</div>

--- a/src/app/pages/admin/tables/admin-tables-menu.component.scss
+++ b/src/app/pages/admin/tables/admin-tables-menu.component.scss
@@ -1,0 +1,56 @@
+.tables-menu {
+  padding: 24px;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.menu-header {
+  margin-bottom: 24px;
+
+  h2 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+}
+
+.tile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.tile {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 24px 20px;
+  cursor: pointer;
+  color: inherit;
+  text-align: left;
+  transition: background 0.15s;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  position: relative;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.tile-label {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.tile-subtitle {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.tile-badge {
+  font-size: 0.7rem;
+  color: #10b981;
+  margin-top: 4px;
+}

--- a/src/app/pages/admin/tables/admin-tables-menu.component.ts
+++ b/src/app/pages/admin/tables/admin-tables-menu.component.ts
@@ -1,0 +1,52 @@
+import { Component } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { Router } from '@angular/router'
+
+interface TablesTile {
+  label: string
+  subtitle: string
+  route: string
+  external?: boolean
+  tooltip?: string
+}
+
+/**
+ * Admin Tables menu — 3 tiles:
+ *   1. Users  → /admin/tables/users
+ *   2. Leagues → /admin/tables/leagues
+ *   3. Reports Flags → /admin/ai-review (tooltip: "flags live on each report row")
+ * Mirrors iOS AdminView's 3rd tile deep-link to the AI Review redact menu.
+ */
+@Component({
+  selector: 'app-admin-tables-menu',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './admin-tables-menu.component.html',
+  styleUrls: ['./admin-tables-menu.component.scss'],
+})
+export class AdminTablesMenuComponent {
+  tiles: TablesTile[] = [
+    {
+      label: 'Users',
+      subtitle: 'Manage whitelisted users',
+      route: '/admin/tables/users',
+    },
+    {
+      label: 'Leagues',
+      subtitle: 'Manage whitelisted leagues',
+      route: '/admin/tables/leagues',
+    },
+    {
+      label: 'Report Flags',
+      subtitle: 'Do-not-broadcast / redact flags',
+      route: '/admin/ai-review',
+      tooltip: 'Flags live on each report row in AI Review',
+    },
+  ]
+
+  constructor(private router: Router) {}
+
+  navigate(tile: TablesTile): void {
+    this.router.navigate([tile.route])
+  }
+}

--- a/src/app/pages/admin/tables/leagues/edit/admin-league-edit.component.html
+++ b/src/app/pages/admin/tables/leagues/edit/admin-league-edit.component.html
@@ -1,0 +1,61 @@
+<div class="league-edit">
+  <div class="edit-header">
+    <button class="btn-back" (click)="cancel()">← Back</button>
+    <h2>Edit League</h2>
+  </div>
+
+  <div *ngIf="isLoading" class="state-loading"><p>Loading…</p></div>
+
+  <ng-container *ngIf="!isLoading && league">
+    <!-- Read-only labels -->
+    <div class="readonly-section">
+      <div class="readonly-row">
+        <span class="readonly-label">League ID</span>
+        <span class="readonly-value">{{ leagueId }}</span>
+      </div>
+      <div class="readonly-row">
+        <span class="readonly-label">Season</span>
+        <span class="readonly-value">{{ season }}</span>
+      </div>
+    </div>
+
+    <form [formGroup]="form" (ngSubmit)="submit()" class="edit-form">
+      <div class="field-group">
+        <label for="leagueName">League Name</label>
+        <input id="leagueName" type="text" formControlName="leagueName" autocomplete="off" />
+        <p *ngIf="form.get('leagueName')?.touched && form.get('leagueName')?.hasError('required')" class="field-error">League name is required.</p>
+      </div>
+
+      <div class="field-group field-row">
+        <label for="isActive">Active</label>
+        <input id="isActive" type="checkbox" formControlName="isActive" />
+      </div>
+
+      <div class="field-group field-row">
+        <label for="isDynasty">Dynasty</label>
+        <input id="isDynasty" type="checkbox" formControlName="isDynasty" />
+      </div>
+
+      <div class="field-group field-row">
+        <label for="hasTaxi">Has Taxi Squad</label>
+        <input id="hasTaxi" type="checkbox" formControlName="hasTaxi" />
+      </div>
+
+      <p *ngIf="error" class="feedback-error">{{ error }}</p>
+      <p *ngIf="successMessage" class="feedback-success">{{ successMessage }}</p>
+
+      <div class="form-actions">
+        <button type="button" class="btn-secondary" (click)="cancel()">Cancel</button>
+        <button type="submit" class="btn-primary" [disabled]="form.invalid || isSaving">
+          <span *ngIf="isSaving" class="spinner-sm"></span>
+          <span *ngIf="!isSaving">Save</span>
+        </button>
+      </div>
+    </form>
+  </ng-container>
+
+  <div *ngIf="!isLoading && error && !league" class="state-loading">
+    <p class="error-text">{{ error }}</p>
+    <button class="btn-secondary" (click)="cancel()">Back</button>
+  </div>
+</div>

--- a/src/app/pages/admin/tables/leagues/edit/admin-league-edit.component.scss
+++ b/src/app/pages/admin/tables/leagues/edit/admin-league-edit.component.scss
@@ -1,0 +1,141 @@
+.league-edit {
+  padding: 24px;
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.edit-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 28px;
+
+  h2 { margin: 0; font-size: 1.4rem; font-weight: 600; }
+}
+
+.btn-back {
+  background: none;
+  border: none;
+  color: #10b981;
+  cursor: pointer;
+  font-size: 0.95rem;
+  padding: 0;
+  &:hover { text-decoration: underline; }
+}
+
+.readonly-section {
+  background: rgba(255,255,255,0.04);
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.readonly-row { display: flex; gap: 12px; font-size: 0.85rem; }
+.readonly-label { color: rgba(255,255,255,0.5); min-width: 100px; }
+.readonly-value { color: rgba(255,255,255,0.8); font-family: monospace; word-break: break-all; }
+
+.edit-form { display: flex; flex-direction: column; gap: 18px; }
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  &.field-row {
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    label { margin-bottom: 0; }
+  }
+
+  label { font-size: 0.875rem; font-weight: 500; color: rgba(255,255,255,0.7); }
+}
+
+input[type="text"] {
+  background: rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 8px;
+  color: #fff;
+  font-size: 0.9rem;
+  padding: 10px 12px;
+  outline: none;
+  &:focus { border-color: #10b981; }
+  &::placeholder { color: rgba(255,255,255,0.3); }
+}
+
+input[type="checkbox"] { width: 18px; height: 18px; cursor: pointer; }
+
+.field-error { font-size: 0.75rem; color: #f87171; margin: 0; }
+.feedback-error   { color: #f87171; font-size: 0.875rem; margin: 0; }
+.feedback-success { color: #34d399; font-size: 0.875rem; margin: 0; }
+.error-text { color: #f87171; }
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+
+  .btn-secondary {
+    flex: 1;
+    background: rgba(255,255,255,0.1);
+    color: #fff;
+    border: 1px solid rgba(255,255,255,0.2);
+    border-radius: 8px;
+    padding: 10px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    &:hover { background: rgba(255,255,255,0.15); }
+  }
+
+  .btn-primary {
+    flex: 2;
+    background: #10b981;
+    color: #000;
+    border: none;
+    border-radius: 8px;
+    padding: 10px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
+    &:hover:not(:disabled) { background: #059669; }
+  }
+}
+
+.state-loading {
+  padding: 48px 0;
+  text-align: center;
+  color: rgba(255,255,255,0.5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.btn-secondary {
+  background: rgba(255,255,255,0.1);
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.spinner-sm {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(0,0,0,0.3);
+  border-top-color: #000;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }

--- a/src/app/pages/admin/tables/leagues/edit/admin-league-edit.component.ts
+++ b/src/app/pages/admin/tables/leagues/edit/admin-league-edit.component.ts
@@ -1,0 +1,132 @@
+import { Component, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { ActivatedRoute, Router } from '@angular/router'
+import {
+  ReactiveFormsModule,
+  FormBuilder,
+  FormGroup,
+  Validators,
+} from '@angular/forms'
+import { TablesService } from 'src/app/services/tables.service'
+import { WhitelistedLeague } from 'src/app/models/whitelisted-league.model'
+import { AdminFieldValue } from 'src/app/models/admin-field-value.model'
+
+@Component({
+  selector: 'app-admin-league-edit',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './admin-league-edit.component.html',
+  styleUrls: ['./admin-league-edit.component.scss'],
+})
+export class AdminLeagueEditComponent implements OnInit {
+  form!: FormGroup
+  league: WhitelistedLeague | null = null
+  isLoading = false
+  isSaving = false
+  error: string | null = null
+  successMessage: string | null = null
+
+  constructor(
+    private fb: FormBuilder,
+    private route: ActivatedRoute,
+    private router: Router,
+    private tablesService: TablesService,
+  ) {}
+
+  ngOnInit(): void {
+    this.buildForm()
+    const id = this.route.snapshot.paramMap.get('id')
+    if (id) this.loadLeague(id)
+  }
+
+  private buildForm(): void {
+    this.form = this.fb.group({
+      leagueName: ['', [Validators.required, Validators.maxLength(200)]],
+      isActive:   [false],
+      isDynasty:  [false],
+      hasTaxi:    [false],
+    })
+  }
+
+  private loadLeague(id: string): void {
+    this.isLoading = true
+    this.tablesService.listLeagues().subscribe({
+      next: (leagues) => {
+        this.isLoading = false
+        const found = leagues.find((l) => l.id === id) ?? null
+        if (!found) {
+          this.error = 'League not found.'
+          return
+        }
+        this.league = found
+        this.form.patchValue({
+          leagueName: found.leagueName,
+          isActive:   found.isActive,
+          isDynasty:  found.isDynasty,
+          hasTaxi:    found.hasTaxi,
+        })
+      },
+      error: (err: unknown) => {
+        this.isLoading = false
+        this.error = err instanceof Error ? err.message : 'Failed to load league.'
+      },
+    })
+  }
+
+  submit(): void {
+    if (this.form.invalid || this.isSaving || !this.league) return
+    this.error = null
+    this.successMessage = null
+
+    const diff = this.buildDiff()
+    if (Object.keys(diff).length === 0) {
+      this.successMessage = 'No changes detected.'
+      return
+    }
+
+    this.isSaving = true
+    this.tablesService.updateLeague(this.league.leagueId, diff).subscribe({
+      next: () => {
+        this.isSaving = false
+        this.successMessage = 'Saved.'
+        const v = this.form.value as { leagueName: string; isActive: boolean; isDynasty: boolean; hasTaxi: boolean }
+        this.league = {
+          ...this.league!,
+          leagueName: v.leagueName.trim(),
+          isActive: v.isActive,
+          isDynasty: v.isDynasty,
+          hasTaxi: v.hasTaxi,
+        }
+      },
+      error: (err: unknown) => {
+        this.isSaving = false
+        this.error = err instanceof Error ? err.message : 'Save failed.'
+      },
+    })
+  }
+
+  private buildDiff(): Record<string, AdminFieldValue> {
+    const orig = this.league!
+    const v = this.form.value as { leagueName: string; isActive: boolean; isDynasty: boolean; hasTaxi: boolean }
+    const diff: Record<string, AdminFieldValue> = {}
+
+    if (v.leagueName.trim() !== orig.leagueName) diff['league_name'] = { kind: 'string', value: v.leagueName.trim() }
+    if (v.isActive  !== orig.isActive)            diff['is_active']  = { kind: 'bool',   value: v.isActive }
+    if (v.isDynasty !== orig.isDynasty)           diff['is_dynasty'] = { kind: 'bool',   value: v.isDynasty }
+    if (v.hasTaxi   !== orig.hasTaxi)             diff['has_taxi']   = { kind: 'bool',   value: v.hasTaxi }
+
+    return diff
+  }
+
+  cancel(): void {
+    this.router.navigate(['/admin/tables/leagues'])
+  }
+
+  get leagueId(): string {
+    return this.league?.leagueId ?? '—'
+  }
+
+  get season(): string {
+    return this.league?.season ?? '—'
+  }
+}

--- a/src/app/pages/admin/tables/leagues/list/admin-tables-leagues.component.html
+++ b/src/app/pages/admin/tables/leagues/list/admin-tables-leagues.component.html
@@ -1,0 +1,32 @@
+<div class="leagues-list">
+  <div class="list-header">
+    <h2>Leagues</h2>
+  </div>
+
+  <div *ngIf="isLoading" class="state-empty"><p>Loading…</p></div>
+
+  <div *ngIf="!isLoading && error" class="state-empty state-error">
+    <p>{{ error }}</p>
+    <button class="btn-secondary" (click)="load()">Retry</button>
+  </div>
+
+  <div *ngIf="!isLoading && !error && leagues.length === 0" class="state-empty">
+    <p>No leagues found.</p>
+  </div>
+
+  <ul *ngIf="!isLoading && !error && leagues.length > 0" class="row-list">
+    <li *ngFor="let league of leagues" class="row-item" (click)="navigateEdit(league)">
+      <div class="row-info">
+        <span class="row-name">{{ league.leagueName }}</span>
+        <span class="row-meta">Season {{ league.season }} · ID {{ league.leagueId }}</span>
+      </div>
+      <div class="row-chips">
+        <span class="chip" [class.chip-active]="league.isActive" [class.chip-inactive]="!league.isActive">
+          {{ league.isActive ? 'Active' : 'Inactive' }}
+        </span>
+        <span *ngIf="league.isDynasty" class="chip chip-tag">Dynasty</span>
+        <span *ngIf="league.hasTaxi" class="chip chip-tag">Taxi</span>
+      </div>
+    </li>
+  </ul>
+</div>

--- a/src/app/pages/admin/tables/leagues/list/admin-tables-leagues.component.scss
+++ b/src/app/pages/admin/tables/leagues/list/admin-tables-leagues.component.scss
@@ -1,0 +1,80 @@
+.leagues-list {
+  padding: 24px;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.list-header {
+  margin-bottom: 24px;
+  h2 { margin: 0; font-size: 1.5rem; font-weight: 600; }
+}
+
+.state-empty {
+  text-align: center;
+  padding: 48px 16px;
+  color: rgba(255,255,255,0.5);
+  &.state-error { color: #f87171; }
+}
+
+.btn-secondary {
+  margin-top: 12px;
+  background: rgba(255,255,255,0.1);
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.row-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.row-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(255,255,255,0.05);
+  border-radius: 12px;
+  padding: 14px 16px;
+  cursor: pointer;
+  transition: background 0.15s;
+  &:hover { background: rgba(255,255,255,0.09); }
+}
+
+.row-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.row-name { font-weight: 600; font-size: 0.95rem; }
+.row-meta { font-size: 0.78rem; color: rgba(255,255,255,0.45); }
+
+.row-chips {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+  margin-left: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.chip {
+  font-size: 0.72rem;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-weight: 500;
+  white-space: nowrap;
+
+  &.chip-active   { background: rgba(16,185,129,0.2); color: #34d399; }
+  &.chip-inactive { background: rgba(255,255,255,0.08); color: rgba(255,255,255,0.4); }
+  &.chip-tag      { background: rgba(255,255,255,0.1); color: rgba(255,255,255,0.7); }
+}

--- a/src/app/pages/admin/tables/leagues/list/admin-tables-leagues.component.ts
+++ b/src/app/pages/admin/tables/leagues/list/admin-tables-leagues.component.ts
@@ -1,0 +1,46 @@
+import { Component, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { Router } from '@angular/router'
+import { TablesService } from 'src/app/services/tables.service'
+import { WhitelistedLeague } from 'src/app/models/whitelisted-league.model'
+
+@Component({
+  selector: 'app-admin-tables-leagues',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './admin-tables-leagues.component.html',
+  styleUrls: ['./admin-tables-leagues.component.scss'],
+})
+export class AdminTablesLeaguesComponent implements OnInit {
+  leagues: WhitelistedLeague[] = []
+  isLoading = false
+  error: string | null = null
+
+  constructor(
+    private tablesService: TablesService,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.load()
+  }
+
+  load(): void {
+    this.isLoading = true
+    this.error = null
+    this.tablesService.listLeagues().subscribe({
+      next: (leagues) => {
+        this.leagues = leagues
+        this.isLoading = false
+      },
+      error: (err: unknown) => {
+        this.error = err instanceof Error ? err.message : 'Failed to load leagues.'
+        this.isLoading = false
+      },
+    })
+  }
+
+  navigateEdit(league: WhitelistedLeague): void {
+    this.router.navigate(['/admin/tables/leagues', league.id])
+  }
+}

--- a/src/app/pages/admin/tables/users/edit/admin-user-edit.component.html
+++ b/src/app/pages/admin/tables/users/edit/admin-user-edit.component.html
@@ -1,0 +1,62 @@
+<div class="user-edit">
+  <div class="edit-header">
+    <button class="btn-back" (click)="cancel()">← Back</button>
+    <h2>Edit User</h2>
+  </div>
+
+  <div *ngIf="isLoading" class="state-loading"><p>Loading…</p></div>
+
+  <ng-container *ngIf="!isLoading && user">
+    <!-- Read-only labels -->
+    <div class="readonly-section">
+      <div class="readonly-row">
+        <span class="readonly-label">User ID</span>
+        <span class="readonly-value">{{ userId }}</span>
+      </div>
+      <div class="readonly-row">
+        <span class="readonly-label">Sleeper ID</span>
+        <span class="readonly-value">{{ sleeperUserId }}</span>
+      </div>
+    </div>
+
+    <form [formGroup]="form" (ngSubmit)="submit()" class="edit-form">
+      <div class="field-group">
+        <label for="email">Email</label>
+        <input id="email" type="email" formControlName="email" autocomplete="off" />
+        <p *ngIf="form.get('email')?.touched && form.get('email')?.hasError('required')" class="field-error">Email is required.</p>
+        <p *ngIf="form.get('email')?.touched && form.get('email')?.hasError('adminEmail')" class="field-error">Invalid email format.</p>
+      </div>
+
+      <div class="field-group">
+        <label for="displayName">Display Name</label>
+        <input id="displayName" type="text" formControlName="displayName" autocomplete="off" />
+      </div>
+
+      <div class="field-group field-row">
+        <label for="isAdmin">Admin</label>
+        <input id="isAdmin" type="checkbox" formControlName="isAdmin" />
+      </div>
+
+      <div class="field-group field-row">
+        <label for="isActive">Active</label>
+        <input id="isActive" type="checkbox" formControlName="isActive" />
+      </div>
+
+      <p *ngIf="error" class="feedback-error">{{ error }}</p>
+      <p *ngIf="successMessage" class="feedback-success">{{ successMessage }}</p>
+
+      <div class="form-actions">
+        <button type="button" class="btn-secondary" (click)="cancel()">Cancel</button>
+        <button type="submit" class="btn-primary" [disabled]="form.invalid || isSaving">
+          <span *ngIf="isSaving" class="spinner-sm"></span>
+          <span *ngIf="!isSaving">Save</span>
+        </button>
+      </div>
+    </form>
+  </ng-container>
+
+  <div *ngIf="!isLoading && error && !user" class="state-loading">
+    <p class="error-text">{{ error }}</p>
+    <button class="btn-secondary" (click)="cancel()">Back</button>
+  </div>
+</div>

--- a/src/app/pages/admin/tables/users/edit/admin-user-edit.component.scss
+++ b/src/app/pages/admin/tables/users/edit/admin-user-edit.component.scss
@@ -1,0 +1,149 @@
+.user-edit {
+  padding: 24px;
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.edit-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 28px;
+
+  h2 { margin: 0; font-size: 1.4rem; font-weight: 600; }
+}
+
+.btn-back {
+  background: none;
+  border: none;
+  color: #10b981;
+  cursor: pointer;
+  font-size: 0.95rem;
+  padding: 0;
+  &:hover { text-decoration: underline; }
+}
+
+.readonly-section {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.readonly-row {
+  display: flex;
+  gap: 12px;
+  font-size: 0.85rem;
+}
+.readonly-label { color: rgba(255,255,255,0.5); min-width: 100px; }
+.readonly-value { color: rgba(255,255,255,0.8); font-family: monospace; word-break: break-all; }
+
+.edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  &.field-row {
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    label { margin-bottom: 0; }
+  }
+
+  label { font-size: 0.875rem; font-weight: 500; color: rgba(255,255,255,0.7); }
+}
+
+input[type="text"], input[type="email"] {
+  background: rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 8px;
+  color: #fff;
+  font-size: 0.9rem;
+  padding: 10px 12px;
+  outline: none;
+  &:focus { border-color: #10b981; }
+  &::placeholder { color: rgba(255,255,255,0.3); }
+}
+
+input[type="checkbox"] { width: 18px; height: 18px; cursor: pointer; }
+
+.field-error { font-size: 0.75rem; color: #f87171; margin: 0; }
+.feedback-error   { color: #f87171; font-size: 0.875rem; margin: 0; }
+.feedback-success { color: #34d399; font-size: 0.875rem; margin: 0; }
+.error-text { color: #f87171; }
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+
+  .btn-secondary {
+    flex: 1;
+    background: rgba(255,255,255,0.1);
+    color: #fff;
+    border: 1px solid rgba(255,255,255,0.2);
+    border-radius: 8px;
+    padding: 10px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    &:hover { background: rgba(255,255,255,0.15); }
+  }
+
+  .btn-primary {
+    flex: 2;
+    background: #10b981;
+    color: #000;
+    border: none;
+    border-radius: 8px;
+    padding: 10px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
+    &:hover:not(:disabled) { background: #059669; }
+  }
+}
+
+.state-loading {
+  padding: 48px 0;
+  text-align: center;
+  color: rgba(255,255,255,0.5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.btn-secondary {
+  background: rgba(255,255,255,0.1);
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.spinner-sm {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(0,0,0,0.3);
+  border-top-color: #000;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }

--- a/src/app/pages/admin/tables/users/edit/admin-user-edit.component.ts
+++ b/src/app/pages/admin/tables/users/edit/admin-user-edit.component.ts
@@ -1,0 +1,160 @@
+import { Component, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { ActivatedRoute, Router } from '@angular/router'
+import {
+  ReactiveFormsModule,
+  FormBuilder,
+  FormGroup,
+  Validators,
+  AbstractControl,
+  ValidationErrors,
+} from '@angular/forms'
+import { TablesService } from 'src/app/services/tables.service'
+import { WhitelistedUser } from 'src/app/models/whitelisted-user.model'
+import { AdminFieldValue } from 'src/app/models/admin-field-value.model'
+import { ADMIN_EMAIL_REGEX } from 'src/app/models/admin-validation'
+
+/** Custom validator mirroring iOS AdminValidation.isValidEmail */
+function adminEmailValidator(control: AbstractControl): ValidationErrors | null {
+  const v = (control.value as string | null) ?? ''
+  if (!v.trim()) return null  // required validator handles empty
+  return ADMIN_EMAIL_REGEX.test(v.trim()) ? null : { adminEmail: true }
+}
+
+@Component({
+  selector: 'app-admin-user-edit',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './admin-user-edit.component.html',
+  styleUrls: ['./admin-user-edit.component.scss'],
+})
+export class AdminUserEditComponent implements OnInit {
+  form!: FormGroup
+  user: WhitelistedUser | null = null
+  isLoading = false
+  isSaving = false
+  error: string | null = null
+  successMessage: string | null = null
+
+  constructor(
+    private fb: FormBuilder,
+    private route: ActivatedRoute,
+    private router: Router,
+    private tablesService: TablesService,
+  ) {}
+
+  ngOnInit(): void {
+    this.buildForm()
+    const id = this.route.snapshot.paramMap.get('id')
+    if (id) this.loadUser(id)
+  }
+
+  private buildForm(): void {
+    this.form = this.fb.group({
+      email:       ['', [Validators.required, adminEmailValidator]],
+      displayName: [''],
+      isAdmin:     [false],
+      isActive:    [false],
+    })
+  }
+
+  private loadUser(id: string): void {
+    this.isLoading = true
+    this.tablesService.listUsers().subscribe({
+      next: (users) => {
+        this.isLoading = false
+        const found = users.find((u) => u.id === id) ?? null
+        if (!found) {
+          this.error = 'User not found.'
+          return
+        }
+        this.user = found
+        this.form.patchValue({
+          email:       found.email,
+          displayName: found.displayName ?? '',
+          isAdmin:     found.isAdmin,
+          isActive:    found.isActive,
+        })
+      },
+      error: (err: unknown) => {
+        this.isLoading = false
+        this.error = err instanceof Error ? err.message : 'Failed to load user.'
+      },
+    })
+  }
+
+  submit(): void {
+    if (this.form.invalid || this.isSaving || !this.user) return
+    this.error = null
+    this.successMessage = null
+
+    const diff = this.buildDiff()
+    if (Object.keys(diff).length === 0) {
+      this.successMessage = 'No changes detected.'
+      return
+    }
+
+    this.isSaving = true
+    // updateKey is the user's email — the backend's lookup key.
+    this.tablesService.updateUser(this.user.email, diff).subscribe({
+      next: () => {
+        this.isSaving = false
+        this.successMessage = 'Saved.'
+        // Patch local user to reflect the diff so re-saves are accurate.
+        const v = this.form.value as { email: string; displayName: string; isAdmin: boolean; isActive: boolean }
+        this.user = {
+          ...this.user!,
+          email: v.email.trim(),
+          displayName: v.displayName.trim() || null,
+          isAdmin: v.isAdmin,
+          isActive: v.isActive,
+        }
+      },
+      error: (err: unknown) => {
+        this.isSaving = false
+        this.error = err instanceof Error ? err.message : 'Save failed.'
+      },
+    })
+  }
+
+  private buildDiff(): Record<string, AdminFieldValue> {
+    const orig = this.user!
+    const v = this.form.value as {
+      email: string
+      displayName: string
+      isAdmin: boolean
+      isActive: boolean
+    }
+    const diff: Record<string, AdminFieldValue> = {}
+
+    const emailTrimmed = v.email.trim()
+    const displayNameTrimmed = v.displayName.trim()
+
+    if (emailTrimmed !== orig.email)
+      diff['email'] = { kind: 'string', value: emailTrimmed }
+    if (displayNameTrimmed !== (orig.displayName ?? ''))
+      diff['display_name'] = displayNameTrimmed
+        ? { kind: 'string', value: displayNameTrimmed }
+        : { kind: 'null' }
+    if (v.isAdmin !== orig.isAdmin)
+      diff['is_admin'] = { kind: 'bool', value: v.isAdmin }
+    if (v.isActive !== orig.isActive)
+      diff['is_active'] = { kind: 'bool', value: v.isActive }
+
+    return diff
+  }
+
+  cancel(): void {
+    this.router.navigate(['/admin/tables/users'])
+  }
+
+  /** Read-only display: user ID. */
+  get userId(): string {
+    return this.user?.id ?? '—'
+  }
+
+  /** Read-only display: Sleeper user ID. */
+  get sleeperUserId(): string {
+    return this.user?.sleeperUserId ?? '—'
+  }
+}

--- a/src/app/pages/admin/tables/users/list/admin-tables-users.component.html
+++ b/src/app/pages/admin/tables/users/list/admin-tables-users.component.html
@@ -1,0 +1,35 @@
+<div class="users-list">
+  <div class="list-header">
+    <h2>Users</h2>
+  </div>
+
+  <div *ngIf="isLoading" class="state-empty">
+    <p>Loading…</p>
+  </div>
+
+  <div *ngIf="!isLoading && error" class="state-empty state-error">
+    <p>{{ error }}</p>
+    <button class="btn-secondary" (click)="load()">Retry</button>
+  </div>
+
+  <div *ngIf="!isLoading && !error && users.length === 0" class="state-empty">
+    <p>No users found.</p>
+  </div>
+
+  <ul *ngIf="!isLoading && !error && users.length > 0" class="row-list">
+    <li *ngFor="let user of users" class="row-item" (click)="navigateEdit(user)">
+      <div class="row-info">
+        <span class="row-name">{{ displayLabel(user) }}</span>
+        <span class="row-email">{{ user.email }}</span>
+      </div>
+      <div class="row-chips">
+        <span class="chip" [class.chip-admin]="user.isAdmin" [class.chip-member]="!user.isAdmin">
+          {{ user.isAdmin ? 'Admin' : (user.role || 'Member') }}
+        </span>
+        <span class="chip" [class.chip-active]="user.isActive" [class.chip-inactive]="!user.isActive">
+          {{ user.isActive ? 'Active' : 'Inactive' }}
+        </span>
+      </div>
+    </li>
+  </ul>
+</div>

--- a/src/app/pages/admin/tables/users/list/admin-tables-users.component.scss
+++ b/src/app/pages/admin/tables/users/list/admin-tables-users.component.scss
@@ -1,0 +1,94 @@
+.users-list {
+  padding: 24px;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.list-header {
+  margin-bottom: 24px;
+
+  h2 { margin: 0; font-size: 1.5rem; font-weight: 600; }
+}
+
+.state-empty {
+  text-align: center;
+  padding: 48px 16px;
+  color: rgba(255, 255, 255, 0.5);
+  &.state-error { color: #f87171; }
+}
+
+.btn-secondary {
+  margin-top: 12px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.row-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.row-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 14px 16px;
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover { background: rgba(255, 255, 255, 0.09); }
+}
+
+.row-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.row-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row-email {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row-chips {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+  margin-left: 12px;
+}
+
+.chip {
+  font-size: 0.72rem;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-weight: 500;
+  white-space: nowrap;
+
+  &.chip-admin    { background: rgba(16, 185, 129, 0.2); color: #34d399; }
+  &.chip-member   { background: rgba(255, 255, 255, 0.08); color: rgba(255,255,255,0.6); }
+  &.chip-active   { background: rgba(16, 185, 129, 0.15); color: #34d399; }
+  &.chip-inactive { background: rgba(255,255,255,0.08); color: rgba(255,255,255,0.4); }
+}

--- a/src/app/pages/admin/tables/users/list/admin-tables-users.component.ts
+++ b/src/app/pages/admin/tables/users/list/admin-tables-users.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { Router } from '@angular/router'
+import { TablesService } from 'src/app/services/tables.service'
+import { WhitelistedUser } from 'src/app/models/whitelisted-user.model'
+
+@Component({
+  selector: 'app-admin-tables-users',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './admin-tables-users.component.html',
+  styleUrls: ['./admin-tables-users.component.scss'],
+})
+export class AdminTablesUsersComponent implements OnInit {
+  users: WhitelistedUser[] = []
+  isLoading = false
+  error: string | null = null
+
+  constructor(
+    private tablesService: TablesService,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.load()
+  }
+
+  load(): void {
+    this.isLoading = true
+    this.error = null
+    this.tablesService.listUsers().subscribe({
+      next: (users) => {
+        this.users = users
+        this.isLoading = false
+      },
+      error: (err: unknown) => {
+        this.error = err instanceof Error ? err.message : 'Failed to load users.'
+        this.isLoading = false
+      },
+    })
+  }
+
+  navigateEdit(user: WhitelistedUser): void {
+    this.router.navigate(['/admin/tables/users', user.id])
+  }
+
+  displayLabel(user: WhitelistedUser): string {
+    return user.displayName || user.sleeperUsername || user.email
+  }
+}

--- a/src/app/services/announcements.service.ts
+++ b/src/app/services/announcements.service.ts
@@ -6,22 +6,30 @@ import { environment } from 'src/environments/environment'
 import {
   LeagueAnnouncement,
   AnnouncementsListResponse,
+  AdminAnnouncementsListResponse,
+  AnnouncementMutationResponse,
+  AnnouncementCreateInput,
   mapAnnouncement,
 } from '../models/league-announcement.model'
+import { AdminFieldValue, adminFieldValueToJson } from '../models/admin-field-value.model'
 
 /**
- * Public read-only surface for league announcements.
- * Mirrors iOS AnnouncementsStore.load() — calls GET /announcements/list,
- * then applies the same defensive client-side filter iOS uses:
- *   isActive && (!expiresAt || expiresAt > now)
- * Sort: critical-first, then displayOrder ascending.
+ * Public read-only + admin CRUD surface for league announcements.
  *
- * Admin CRUD surface lands in s7.
+ * Public read: GET /announcements/list — filtered active + non-expired rows.
+ * Admin CRUD: GET/POST /admin/announcements-* — all rows including inactive.
+ *
+ * Admin cache: listAdmin() result is held in _adminCache for getById()
+ * resolution so the edit form doesn't require a separate detail endpoint
+ * (mirrors iOS AnnouncementsStore behaviour).
  */
 @Injectable({ providedIn: 'root' })
 export class AnnouncementsService {
   private readonly apiUrl = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`
   private readonly apiAuthToken = environment.apiAuthToken
+
+  /** In-memory cache from the last successful listAdmin() call. */
+  private _adminCache: LeagueAnnouncement[] = []
 
   constructor(private http: HttpClient) {}
 
@@ -61,6 +69,113 @@ export class AnnouncementsService {
             })
         }),
         catchError(() => of([])),
+      )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Admin CRUD
+  // ---------------------------------------------------------------------------
+
+  /**
+   * GET /admin/announcements-list
+   * Returns every row (active + inactive + expired) for the admin list view.
+   * Populates _adminCache for getById() resolution.
+   */
+  listAdmin(): Observable<{ rows: LeagueAnnouncement[]; tableMissing: boolean }> {
+    return this.http
+      .get<AdminAnnouncementsListResponse>(`${this.apiUrl}/admin/announcements-list`, {
+        headers: this.headers,
+      })
+      .pipe(
+        map((response) => {
+          const rows = (response.rows ?? []).map(mapAnnouncement)
+          this._adminCache = rows
+          return { rows, tableMissing: response.table_missing ?? false }
+        }),
+      )
+  }
+
+  /**
+   * Resolve an announcement by ID from the in-memory admin cache.
+   * If the cache is empty, fires listAdmin() first.
+   */
+  getById(id: string): Observable<LeagueAnnouncement | null> {
+    const fromCache = this._adminCache.find((a) => a.id === id) ?? null
+    if (fromCache) return of(fromCache)
+    return this.listAdmin().pipe(
+      map(({ rows }) => rows.find((a) => a.id === id) ?? null),
+    )
+  }
+
+  /**
+   * POST /admin/announcements-create
+   * Creates a new announcement row. Returns the server-resolved row.
+   */
+  create(input: AnnouncementCreateInput): Observable<LeagueAnnouncement> {
+    const body: Record<string, unknown> = {
+      title: input.title,
+      body: input.body,
+      priority: input.priority,
+      is_active: input.is_active,
+      display_order: input.display_order,
+    }
+    if (input.expires_at != null) {
+      body['expires_at'] = input.expires_at
+    }
+    return this.http
+      .post<AnnouncementMutationResponse>(`${this.apiUrl}/admin/announcements-create`, body, {
+        headers: this.headers,
+      })
+      .pipe(
+        map((response) => {
+          const row = mapAnnouncement(response.row)
+          this._adminCache = [row, ...this._adminCache.filter((a) => a.id !== row.id)]
+          return row
+        }),
+      )
+  }
+
+  /**
+   * POST /admin/announcements-update
+   * Sends only the changed fields (diff-on-save matching iOS). Each field
+   * value is an AdminFieldValue discriminated union serialised to a JSON scalar.
+   */
+  update(id: string, fields: Record<string, AdminFieldValue>): Observable<LeagueAnnouncement> {
+    const jsonFields: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(fields)) {
+      jsonFields[key] = adminFieldValueToJson(value)
+    }
+    const body = { id, fields: jsonFields }
+    return this.http
+      .post<AnnouncementMutationResponse>(`${this.apiUrl}/admin/announcements-update`, body, {
+        headers: this.headers,
+      })
+      .pipe(
+        map((response) => {
+          const row = mapAnnouncement(response.row)
+          this._adminCache = this._adminCache.map((a) => (a.id === row.id ? row : a))
+          return row
+        }),
+      )
+  }
+
+  /**
+   * POST /admin/announcements-delete
+   * Soft-deletes the row (sets is_active = false on the backend).
+   * The row remains in the admin list; the public list stops showing it.
+   */
+  softDelete(id: string): Observable<void> {
+    return this.http
+      .post<AnnouncementMutationResponse>(
+        `${this.apiUrl}/admin/announcements-delete`,
+        { id },
+        { headers: this.headers },
+      )
+      .pipe(
+        map((response) => {
+          const row = mapAnnouncement(response.row)
+          this._adminCache = this._adminCache.map((a) => (a.id === row.id ? row : a))
+        }),
       )
   }
 }

--- a/src/app/services/audit.service.ts
+++ b/src/app/services/audit.service.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@angular/core'
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+import { environment } from 'src/environments/environment'
+import {
+  AuditEntry,
+  AuditListResponse,
+  mapAuditEntry,
+} from '../models/audit-entry.model'
+
+/**
+ * Admin Audit service.
+ * Wraps GET /admin/audit-list — cursor-paginated audit feed.
+ *
+ * In-memory cache: _entries holds all loaded rows so the detail component
+ * can resolve an entry by ID without a separate endpoint (mirrors iOS
+ * AuditFeedView which reads from an in-memory store).
+ *
+ * When the user navigates directly to /admin/audit/:id with an empty
+ * cache, AdminAuditDetailComponent calls list(null) to seed the first page,
+ * then searches in _entries. If not found → "entry not found" empty state.
+ */
+@Injectable({ providedIn: 'root' })
+export class AuditService {
+  private readonly apiUrl = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`
+  private readonly apiAuthToken = environment.apiAuthToken
+
+  /** In-memory store for loaded audit entries (deduped by id). */
+  private _entries: AuditEntry[] = []
+
+  constructor(private http: HttpClient) {}
+
+  private get headers(): HttpHeaders {
+    return new HttpHeaders({
+      Authorization: `Bearer ${this.apiAuthToken}`,
+      'Content-Type': 'application/json',
+    })
+  }
+
+  /** All entries loaded so far (read-only snapshot). */
+  get cachedEntries(): readonly AuditEntry[] {
+    return this._entries
+  }
+
+  /** Find an entry from the in-memory cache. */
+  getFromCache(id: string): AuditEntry | null {
+    return this._entries.find((e) => e.id === id) ?? null
+  }
+
+  /**
+   * GET /admin/audit-list
+   * cursor: pass null for the first page; pass the previous nextCursor for subsequent pages.
+   * Merges new rows into _entries (deduped by id, newest-first order preserved).
+   */
+  list(cursor: string | null): Observable<{
+    rows: AuditEntry[]
+    nextCursor: string | null
+    tableMissing: boolean
+  }> {
+    let params = new HttpParams()
+    if (cursor) params = params.set('cursor', cursor)
+
+    return this.http
+      .get<AuditListResponse>(`${this.apiUrl}/admin/audit-list`, {
+        headers: this.headers,
+        params,
+      })
+      .pipe(
+        map((response) => {
+          const rows = (response.rows ?? []).map(mapAuditEntry)
+          // Merge into cache — avoid duplicates.
+          const existingIds = new Set(this._entries.map((e) => e.id))
+          for (const row of rows) {
+            if (!existingIds.has(row.id)) {
+              this._entries.push(row)
+              existingIds.add(row.id)
+            }
+          }
+          return {
+            rows,
+            nextCursor: response.next_cursor ?? null,
+            tableMissing: response.table_missing ?? false,
+          }
+        }),
+      )
+  }
+
+  /** Clear the in-memory cache (e.g. on admin logout or forced refresh). */
+  clearCache(): void {
+    this._entries = []
+  }
+}

--- a/src/app/services/cron.service.ts
+++ b/src/app/services/cron.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@angular/core'
+import { HttpClient, HttpHeaders } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+import { environment } from 'src/environments/environment'
+import {
+  CronSetting,
+  CronSettingsListResponse,
+  CronSettingUpdateResponse,
+  mapCronSetting,
+  mapCronSettingUpdate,
+} from '../models/cron-setting.model'
+
+/**
+ * Admin Cron Settings service.
+ *
+ * GET  /admin/cron-settings-list  — list all admin_cron_settings rows.
+ * POST /admin/cron-settings-update — patch enabled or test_mode for one row.
+ *
+ * Note: iOS uses /admin/cron-settings-list and /admin/cron-settings-update.
+ * The plan's service signatures use /admin/cron-list and /admin/cron-update —
+ * the iOS source (XomperAPIClient.swift lines 1319–1346) confirms the actual
+ * endpoints are cron-settings-list and cron-settings-update. Using those.
+ */
+@Injectable({ providedIn: 'root' })
+export class CronService {
+  private readonly apiUrl = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`
+  private readonly apiAuthToken = environment.apiAuthToken
+
+  constructor(private http: HttpClient) {}
+
+  private get headers(): HttpHeaders {
+    return new HttpHeaders({
+      Authorization: `Bearer ${this.apiAuthToken}`,
+      'Content-Type': 'application/json',
+    })
+  }
+
+  /** GET /admin/cron-settings-list — returns all cron rows. */
+  list(): Observable<{ rows: CronSetting[]; tableMissing: boolean }> {
+    return this.http
+      .get<CronSettingsListResponse>(`${this.apiUrl}/admin/cron-settings-list`, {
+        headers: this.headers,
+      })
+      .pipe(
+        map((response) => ({
+          rows: (response.rows ?? []).map(mapCronSetting),
+          tableMissing: response.table_missing ?? false,
+        })),
+      )
+  }
+
+  /**
+   * POST /admin/cron-settings-update
+   * Patch the `enabled` field for one row. Backend echoes the resolved row.
+   * Mirrors iOS updateCronSetting(cronKey:enabled:testMode:) with only enabled set.
+   */
+  setEnabled(cronKey: string, enabled: boolean): Observable<Partial<CronSetting>> {
+    const body: Record<string, unknown> = { cron_key: cronKey, enabled }
+    return this.http
+      .post<CronSettingUpdateResponse>(`${this.apiUrl}/admin/cron-settings-update`, body, {
+        headers: this.headers,
+      })
+      .pipe(map(mapCronSettingUpdate))
+  }
+
+  /**
+   * POST /admin/cron-settings-update
+   * Patch the `test_mode` field for one row. Backend echoes the resolved row.
+   */
+  setTestMode(cronKey: string, testMode: boolean): Observable<Partial<CronSetting>> {
+    const body: Record<string, unknown> = { cron_key: cronKey, test_mode: testMode }
+    return this.http
+      .post<CronSettingUpdateResponse>(`${this.apiUrl}/admin/cron-settings-update`, body, {
+        headers: this.headers,
+      })
+      .pipe(map(mapCronSettingUpdate))
+  }
+}

--- a/src/app/services/tables.service.ts
+++ b/src/app/services/tables.service.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@angular/core'
+import { HttpClient, HttpHeaders } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+import { environment } from 'src/environments/environment'
+import {
+  WhitelistedUser,
+  UsersListResponse,
+  UserUpdateResponse,
+  mapWhitelistedUser,
+} from '../models/whitelisted-user.model'
+import {
+  WhitelistedLeague,
+  LeaguesListResponse,
+  LeagueUpdateResponse,
+  mapWhitelistedLeague,
+} from '../models/whitelisted-league.model'
+import { AdminFieldValue, adminFieldValueToJson } from '../models/admin-field-value.model'
+
+/**
+ * Admin Tables service — Users + Leagues CRUD.
+ *
+ * All endpoints are admin-gated Lambdas (no direct Supabase client reads).
+ * Mirrors iOS AdminTablesStore / XomperAPIClient F4 methods.
+ *
+ * Users:
+ *   GET  /admin/users-list   → list whitelisted_users
+ *   POST /admin/users-update → partial update by updateKey (email)
+ *
+ * Leagues:
+ *   GET  /admin/leagues-list   → list whitelisted_leagues
+ *   POST /admin/leagues-update → partial update by leagueId
+ */
+@Injectable({ providedIn: 'root' })
+export class TablesService {
+  private readonly apiUrl = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`
+  private readonly apiAuthToken = environment.apiAuthToken
+
+  constructor(private http: HttpClient) {}
+
+  private get headers(): HttpHeaders {
+    return new HttpHeaders({
+      Authorization: `Bearer ${this.apiAuthToken}`,
+      'Content-Type': 'application/json',
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Users
+  // ---------------------------------------------------------------------------
+
+  /** GET /admin/users-list — returns all whitelisted_users rows. */
+  listUsers(): Observable<WhitelistedUser[]> {
+    return this.http
+      .get<UsersListResponse>(`${this.apiUrl}/admin/users-list`, { headers: this.headers })
+      .pipe(map((response) => (response.users ?? []).map(mapWhitelistedUser)))
+  }
+
+  /**
+   * POST /admin/users-update
+   * updateKey is the user's email (the backend's lookup key for whitelisted_users).
+   * fields is a partial diff — only changed values should be passed.
+   * Mirrors iOS updateKey / AdminFieldValue wire shape.
+   */
+  updateUser(
+    updateKey: string,
+    fields: Record<string, AdminFieldValue>,
+  ): Observable<UserUpdateResponse> {
+    const jsonFields: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(fields)) {
+      jsonFields[key] = adminFieldValueToJson(value)
+    }
+    const body = { update_key: updateKey, fields: jsonFields }
+    return this.http
+      .post<UserUpdateResponse>(`${this.apiUrl}/admin/users-update`, body, {
+        headers: this.headers,
+      })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Leagues
+  // ---------------------------------------------------------------------------
+
+  /** GET /admin/leagues-list — returns all whitelisted_leagues rows. */
+  listLeagues(): Observable<WhitelistedLeague[]> {
+    return this.http
+      .get<LeaguesListResponse>(`${this.apiUrl}/admin/leagues-list`, { headers: this.headers })
+      .pipe(map((response) => (response.leagues ?? []).map(mapWhitelistedLeague)))
+  }
+
+  /**
+   * POST /admin/leagues-update
+   * leagueId is the Sleeper league ID (the backend's lookup key).
+   * fields is a partial diff of changed values.
+   */
+  updateLeague(
+    leagueId: string,
+    fields: Record<string, AdminFieldValue>,
+  ): Observable<LeagueUpdateResponse> {
+    const jsonFields: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(fields)) {
+      jsonFields[key] = adminFieldValueToJson(value)
+    }
+    const body = { league_id: leagueId, fields: jsonFields }
+    return this.http
+      .post<LeagueUpdateResponse>(`${this.apiUrl}/admin/leagues-update`, body, {
+        headers: this.headers,
+      })
+  }
+}


### PR DESCRIPTION
## Summary

- Ships all remaining admin portal CRUD and ops sub-screens (PR 7b of the s7 split)
- `AnnouncementsService` extended with `listAdmin / getById / create / update / softDelete`
- `AdminAnnouncementsListComponent`: active/inactive/expired chips, per-row soft-delete with `ConfirmDialogComponent`, `tableMissing` empty state
- `AdminAnnouncementEditComponent`: Reactive Form with 3-state expiry diff (on→off sends null, off→on sends ISO string, unchanged skipped) — diff-on-save matches iOS
- `TablesService`: `listUsers / updateUser / listLeagues / updateLeague` wrapping `/admin/users-list`, `/admin/users-update`, `/admin/leagues-list`, `/admin/leagues-update`
- `AdminTablesMenuComponent`: 3-tile menu (Users, Leagues, Report Flags → `/admin/ai-review` with tooltip)
- `AdminTablesUsersComponent` + `AdminUserEditComponent`: email regex validator from iOS `AdminValidation.emailRegex`, diff-on-save, read-only user/Sleeper ID labels
- `AdminTablesLeaguesComponent` + `AdminLeagueEditComponent`: read-only leagueId/season, diff-on-save for leagueName/isActive/isDynasty/hasTaxi
- `AuditService`: cursor-paginated list, in-memory cache for detail resolution without a second endpoint
- `AdminAuditFeedComponent`: `IntersectionObserver` infinite scroll, `tableMissing`/empty/error states
- `AdminAuditDetailComponent`: 3 collapsible JSON blocks (Before/After/Metadata), first-page fallback when cache empty on direct nav
- `CronService`: `list / setEnabled / setTestMode` — uses actual iOS endpoint names `cron-settings-list` / `cron-settings-update`
- `AdminCronSettingsComponent`: enabled/testMode toggle pair, sticky gold test-mode banner, per-row pending spinner, `ConfirmDialog` before disabling a cron
- `AdminLogsComponent`: static placeholder — terminal icon + "CloudWatch logs coming soon" (D-D deferral)
- `app-routing.module.ts`: 13 new `/admin/*` child routes registered under `AdminGuard`
- Models: `WhitelistedUser`, `WhitelistedLeague`, `AuditEntry`, `CronSetting`, `AdminValidation`, updated `LeagueAnnouncement`

## Deviations from plan

- CronService endpoint uses `/admin/cron-settings-list` and `/admin/cron-settings-update` (plan spec said `/admin/cron-list` and `/admin/cron-update` — iOS source confirms the longer names are correct)
- `/ultrareview` not available in this environment — skipped, noted in EXECUTION_LOG

## Test plan

- [ ] Navigate to `/admin/announcements` — verify all rows load with correct chips (active/inactive/expired/priority)
- [ ] Tap "+ New" → create an announcement — verify row appears in list after redirect
- [ ] Edit an existing announcement — change one field — verify DevTools POST body contains only that field under `fields`
- [ ] Delete an announcement — confirm dialog appears — verify row updates to inactive after delete
- [ ] Navigate to `/admin/tables` — verify 3 tiles render
- [ ] `/admin/tables/users` — verify user list with role + active chips
- [ ] `/admin/tables/users/:id` — change email (valid format) + isAdmin — verify DevTools shows only changed fields in diff
- [ ] Try invalid email (no TLD) — verify field-level error message
- [ ] `/admin/tables/leagues/:id` — toggle isDynasty — verify diff sends only `is_dynasty`
- [ ] `/admin/audit` — verify infinite scroll fires a second page load on scroll
- [ ] `/admin/audit/:id` — verify 3 JSON blocks render + collapse/expand
- [ ] Navigate directly to `/admin/audit/:id` (hard-reload) — verify component fetches first page and resolves the entry
- [ ] `/admin/cron-settings` — toggle testMode on any row — verify gold banner appears
- [ ] Toggle enabled to off — verify ConfirmDialog appears, cancelling does not change state
- [ ] `/admin/logs` — verify placeholder card renders with "CloudWatch logs coming soon"

Closes #88