### PR TITLE
#92 feat: s4 — draft tab restructure (Live/Mocks/Recap + Picks)

### DIFF
--- a/docs/features/web-ios-parity/s4-draft-tab-restructure/EXECUTION_LOG.md
+++ b/docs/features/web-ios-parity/s4-draft-tab-restructure/EXECUTION_LOG.md
@@ -1,0 +1,80 @@
+# Execution Log: s4 — Draft Tab Restructure
+
+## [2026-06-05 00:00] — Phase 0: Pre-work
+
+- **Action**: Created GitHub issue #92 "web-ios-parity s4: Draft tab restructure" with `epic:web-ios-parity` label. Branched `feature/92-draft-tab-restructure` off `main` (c1eae4d).
+- **Files changed**: none (branch + issue only)
+- **Decisions**: No in-flight PRs touching target files confirmed.
+- **Result**: success
+
+## [2026-06-05 00:01] — Step 1: Routing skeleton
+
+- **Action**: Added nested routes under `/draft-history/:year` with children `live`, `picks`, `recap`, `mocks` in `app-routing.module.ts`. Added root `/draft-history` redirect to current season `live`.
+- **Files changed**: `app-routing.module.ts`
+- **Result**: success
+
+## [2026-06-05 00:02] — Step 2: Shell rewrite
+
+- **Action**: Rewrote `draft-history.component` to per-year shell: year chips + sub-tab bar (Live/Mocks/Recap for current, Picks/Recap for past) + `<router-outlet>`. Season resolution uses `availableSeasons` from history chain.
+- **Files changed**: `draft-history.component.{ts,html,scss}`
+- **Result**: success
+
+## [2026-06-05 00:03] — Step 3: Picks sub-tab
+
+- **Action**: Created `draft-picks.component` lifting existing board/list rendering from old shell.
+- **Files changed**: `pages/draft-history/picks/draft-picks.component.{ts,html,scss}`
+- **Result**: success
+
+## [2026-06-05 00:04] — Step 4: Recap sub-tab
+
+- **Action**: Created `draft-recap.component`. Calls `AiReviewService.list({ type: 'postDraft' })`, matches report to year via `period` field (period contains season year — e.g. `"2025"` for a postDraft report; fell back to `createdAt` year for robustness). Renders via `StyledMarkdownComponent`. Added `TODO(grades)` note.
+- **Files changed**: `pages/draft-history/recap/draft-recap.component.{ts,html,scss}`
+- **Decisions**: Resolved open question — `period` for postDraft reports is the season year string (e.g. `"2025"`), confirmed by `aiReportFormattedPeriod` which returns period unchanged when no 'W' is found. Matching `report.period === year` is correct; `createdAt` fallback is included for safety.
+- **Result**: success
+
+## [2026-06-05 00:05] — Step 5: Mocks sub-tab
+
+- **Action**: Created `draft-mocks.component`. Lists mock reports via `AiReviewService.list({ type: 'mock', forUser })`, each card expands to `StyledMarkdownComponent`. Admin-gated empty state for non-admins.
+- **Files changed**: `pages/draft-history/mocks/draft-mocks.component.{ts,html,scss}`
+- **Result**: success
+
+## [2026-06-05 00:06] — Step 6-9: Live sub-tab (full port)
+
+- **Action**: Created `draft-live.component` porting iOS `LiveDraftView`:
+  - Controls bar: All/My Picks chip toggle + rounds/board view toggle
+  - Countdown header via RxJS `interval(1000)` + `async` pipe
+  - `liveTeamsBySlot`: maps `draft.draft_order` (userId→slot reversed to slot→userId) + league users to get team name per slot
+  - `liveTeamsBySlotByRound`: per-round override using `getTradedPicks` — builds `rosterId→userId` map, then `originalRosterId→currentOwnerId` per traded pick, overrides base slot map
+  - Polling: `interval(5000)` while `drafting`, `interval(30000)` while `pre_draft`, stops on `complete`. Uses `switchMap` + `takeUntilDestroyed`.
+  - Rounds list view with My Picks filter
+  - Board grid view with My Picks dimming (opacity 0.3 for non-mine cells)
+- **Files changed**: `pages/draft-history/live/draft-live.component.{ts,html,scss}`
+- **Decisions**: `draft.draft_order` is `userId→slot` (per Sleeper API); inverted to `slot→userId` for `liveTeamsBySlot`. Traded picks use `roster_id` as the per-round slot key since Sleeper `traded_picks` records use `roster_id` not `draft_slot`.
+- **Result**: success
+
+## [2026-06-05 00:07] — Step 10: Sidebar + nav
+
+- **Action**: Verified `sidebar.entries.ts` already points Draft History at `/draft-history` with `// s4 restructures` comment. No change needed — the shell redirect handles routing to current season.
+- **Files changed**: none
+- **Result**: success (already correct)
+
+## [2026-06-05 00:08] — Build
+
+- **Action**: `npm run build` — clean compile, no errors.
+- **Lazy chunks confirmed**: `draft-live` 18.80 kB, `draft-picks` 8.46 kB, `draft-mocks` 4.71 kB, `draft-recap` 4.03 kB.
+- **Warning**: bundle initial exceeded 512 kB budget (pre-existing, not introduced by s4).
+- **Result**: success
+
+## [2026-06-05 00:09] — Final: Recap period/season resolution
+
+- **Decision**: Resolved open question — `period` for `postDraft` reports is a plain year string (e.g. `"2025"`). Confirmed via `aiReportFormattedPeriod`: returns `period` unchanged when no `'W'` char is present. Matching `report.period === year` is correct. `createdAt` year fallback also implemented for safety.
+- **Result**: no code change needed — implemented as designed in `draft-recap.component.ts`
+
+## Summary
+
+- **Issue**: #92
+- **Branch**: `feature/92-draft-tab-restructure`
+- **Build**: clean (no errors, pre-existing budget warning)
+- **Files created**: 12 (4 × 3-file component triplets)
+- **Files modified**: 3 (`draft-history.component.{ts,html,scss}`, `app-routing.module.ts`)
+- **Deviations**: Draft grades deferred (no web FantasyCalc values service — see `TODO(grades)` in `draft-recap.component.ts`). `sidebar.entries.ts` already pointed at `/draft-history` — no change needed. Routing uses two flat routes (`draft-history` + `draft-history/:year`) instead of nested parent/child-same-component to avoid Angular router double-instantiation issues.

--- a/docs/features/web-ios-parity/s4-draft-tab-restructure/PLAN.md
+++ b/docs/features/web-ios-parity/s4-draft-tab-restructure/PLAN.md
@@ -1,7 +1,8 @@
 # Plan: Web ↔ iOS Parity — s4 Draft Tab Restructure
 
-**Status**: Draft
+**Status**: Done
 **Created**: 2026-06-04
+**Last updated**: 2026-06-05
 **Epic**: [`../PLAN.md`](../PLAN.md)
 **Brainstorm**: [`../BRAINSTORM.md`](../BRAINSTORM.md)
 
@@ -9,65 +10,119 @@
 
 ## TL;DR
 
-Lift `pages/draft-history` to per-year sub-tabs (Live / Mocks / Recap for current season, Picks / Recap for past).
+Restructure the flat `/draft-history` page into an iOS-matching per-year view with sub-tabs. Current season gets **Live / Mocks / Recap**; past seasons get **Picks / Recap**. Live ports the iOS `LiveDraftView` (board grid + rounds list + All/My Picks toggle + `traded_picks` per-round ownership). Recap and Mocks render stored AI reports through the existing `StyledMarkdownComponent` and `AiReviewService`. The heavy `MockDraftEngine` is NOT ported — Mocks is read-only.
 
 ---
 
-## iOS source surfaces
+## Scope
 
-- `Xomper/Features/DraftHistory/DraftHistoryView.swift`
+### In scope
+- Restructure `/draft-history` into a per-year shell with a year switcher and nested sub-tab routes.
+- **Live** (current season): port iOS `LiveDraftView` — board grid + rounds list, All/My Picks toggle, live countdown header, `traded_picks` per-round ownership override, 5s polling while `drafting`.
+- **Picks** (past seasons): the existing past-draft board/list rendering, lifted into a sub-tab.
+- **Recap** (both modes): stored post-draft AI report via `AiReviewService.list({ type: 'postDraft' })` + `StyledMarkdownComponent`. Draft grades port only if a web player-values source exists — it does not today, so grades are **deferred** (see Decisions).
+- **Mocks** (current season): read-only list of stored mock-draft AI reports via `AiReviewService.list({ type: 'mock', forUser })`, rendered with `StyledMarkdownComponent`. Mock-gating already filters non-admins.
 
-## Web surfaces touched
-
-- `pages/draft-history/draft-history.component.*` (restructure to per-year)
-- New sub-components: `draft-live`, `draft-mocks` (placeholder — engine deferred), `draft-recap`, `draft-picks` (past season)
-- `services/league.service.ts` — reused for picks data
-- (Recap data) `ai-review.service.ts` — introduced by s5, consumed here
-
----
-
-## Dependencies
-
-- **s3** (league surface split) — establishes the per-route component pattern this stub plugs into; Rules mega-tab vacated.
-
----
-
-## Open questions for `/plan` to resolve
-
-- [ ] **Year switcher placement**: top-of-page chip row vs. inline tab strip vs. URL segment (`/draft/2026/live`)? Affects deep-linkability and back-button behavior.
-- [ ] **Mocks sub-tab in v1**: ship as an empty placeholder card pointing to "available on iOS" (mirrors brainstorm note that `MockDraftEngine` is iOS-only), or skip the sub-tab entirely for current season until s9b lands?
-- [ ] **Recap sub-tab data source**: depends on `ai-review.service` from s5. If s5 hasn't shipped yet, does s4 ship without Recap or hard-block on s5 first?
-- [ ] **Past-season "Picks" view**: reuse current draft picks table component, or build a read-only variant with different styling?
-
----
-
-## Out of scope
-
-- Building the `MockDraftEngine` port — deferred to a follow-up sub-stub (`s9b-mock-draft-engine` per epic plan risks).
-- Draft Order Proposal route — that's s9.
+### Out of scope
+- `MockDraftEngine` client-side simulation port — deferred (epic risk, `s9b`).
+- Draft grades (`DraftGradeCalculator`) — deferred pending a web FantasyCalc values service.
 - Theme/visual polish — s10.
-- Backend changes. None required.
+- Backend work — none. All endpoints already exist.
+- `DraftOrderProposal` route — s9.
 
 ---
 
-## Backend contract dependencies
+## iOS → Web mapping
 
-| New service(s) | Backend contract used | New backend work? |
+| Sub-tab | iOS source | Web component (new) | Data source |
+|---|---|---|---|
+| Live (current) | `Draft/LiveDraftView.swift` | `draft-live.component` | Sleeper `getDraftsForLeague` + `getDraftPicks` (poll) + `league.getTradedPicks` |
+| Mocks (current) | `Draft/MocksView.swift` | `draft-mocks.component` | `AiReviewService.list({ type: 'mock', forUser })` + `StyledMarkdownComponent` |
+| Recap (both) | `Draft/DraftRecapView.swift` (+ `DraftGradesCard`) | `draft-recap.component` | `AiReviewService.list({ type: 'postDraft' })` + `StyledMarkdownComponent`; grades deferred |
+| Picks (past) | `DraftHistoryView.swift` board/list | `draft-picks.component` | existing `LeagueHistoryService.getDraftHistoryFromChain` |
+| Shell + year switcher | `DraftHistoryView.swift` + `DraftSubTabBar.swift` | `draft-history.component` (rewritten) | `availableSeasons` from history chain |
+
+---
+
+## Phase 0 — pre-work
+
+- [x] Create/locate the GitHub sub-issue for s4 (`epic:web-ios-parity` label); branch `feature/<issue>-draft-tab-restructure` off `main` (master = `c1eae4d`, post-s2).
+- [x] Confirm no in-flight PR touches `pages/draft-history/*`, `app-routing.module.ts`, or `sidebar.entries.ts`.
+- [x] Confirm `StyledMarkdownComponent` (`src/app/components/styled-markdown/`) and `AiReviewService` (s5/s6) are on `main` — both verified present.
+- [x] Confirm `LeagueService.getTradedPicks(leagueId)` exists — verified present (`league.service.ts:130`).
+
+---
+
+## Affected files
+
+| File / Component | Change | Why |
 |---|---|---|
-| — for Live/Picks; Recap consumes `ai-review.service` (from s5) | Lambda `GET /ai-reports/...` (via s5/s6) | No |
+| `pages/draft-history/draft-history.component.{ts,html,scss}` | Rewrite to per-year shell: year switcher + `<router-outlet>` for sub-tabs; resolve current vs past mode | Mirrors iOS `DraftHistoryView` orchestrator |
+| `pages/draft-history/live/draft-live.component.*` | New — port `LiveDraftView` | Live sub-tab |
+| `pages/draft-history/picks/draft-picks.component.*` | New — lift existing board/list rendering | Picks sub-tab (past) |
+| `pages/draft-history/recap/draft-recap.component.*` | New — markdown recap | Recap sub-tab |
+| `pages/draft-history/mocks/draft-mocks.component.*` | New — read-only mock report list | Mocks sub-tab |
+| `services/draft.service.ts` | Add `getTradedPicks` passthrough OR call `league.service` directly; expose poll helper | Live ownership + polling |
+| `app-routing.module.ts` (or `app.routes.ts`) | Nested routes `/draft-history/:year/{live\|picks\|recap\|mocks}` with redirect to default per mode | Bookmarkable deep links |
+| `sidebar.entries.ts` | Point Draft entry at `/draft-history` (default-year redirect) | Nav parity |
+
+---
+
+## Implementation steps
+
+1. **Routing skeleton.** Add nested routes under `/draft-history/:year` with children `live`, `picks`, `recap`, `mocks`. Add a year-level resolver/guard that redirects to the mode default (`live` for current season, `picks` for past) when no child is specified. Mirrors iOS `defaultSubTab(isCurrentSeason:)`.
+2. **Shell rewrite.** Convert `draft-history.component` to render the year switcher (chip row) + sub-tab bar (filtered by `isCurrentSeason = year === nflState.currentSeason`) + `<router-outlet>`. Move season-resolution logic (`availableSeasons`, current-vs-past) here; drop the inline round rendering.
+3. **Picks sub-tab.** Lift the existing `groupByRound` / board / list rendering out of the old component into `draft-picks.component`. Reuse `LeagueHistoryService`. Read-only; this is the past-season default.
+4. **Recap sub-tab.** Build `draft-recap.component`: call `AiReviewService.list({ type: 'postDraft' })`, pick the row matching `:year` (period/season match), render `bodyMarkdown` via `StyledMarkdownComponent`. Empty state when no report. **No grades** — add a `TODO(grades)` note where `DraftGradesCard` would mount.
+5. **Mocks sub-tab.** Build `draft-mocks.component`: `AiReviewService.list({ type: 'mock', forUser: { isAdmin } })`, render a list of report cards each expanding to `StyledMarkdownComponent`. Read-only. Empty state for non-admins / no mocks.
+6. **Live sub-tab — static structure.** Build `draft-live.component` with the controls bar (All/My Picks chips + rounds/board toggle), header card (countdown via RxJS `interval(1000)` → `async` pipe), and slot→team mapping from `draft.draft_order` + league users. Port `liveTeamsBySlot`.
+7. **Live — traded picks.** Port `liveTeamsBySlotByRound`: fetch `league.getTradedPicks(leagueId)`, build `slot → originalRoster → currentOwner` per round, override the base map. Matches iOS exactly.
+8. **Live — polling.** Add a `draft.service` picks-poll: `interval(5000)` (drafting) / `interval(30000)` (pre_draft) / stop (complete), `switchMap` to `getDraftPicks`, `takeUntilDestroyed`. Map picks into a `"round.slot"` cell lookup; flip empty rows/cells to "pick made".
+9. **Live — render modes.** Port rounds-list (`liveRichRow`) and board grid (`liveBoard`/`liveBoardCell`) including My-Picks dimming (board) / filtering (list).
+10. **Sidebar + nav.** Update `sidebar.entries.ts` Draft entry → `/draft-history`; verify deep links to `/:year/:subtab` work and survive refresh.
+11. **Verify `selected-*` mode** is unaffected (epic constraint) — this surface is `my`-league only, confirm no `selected-league` regression.
+12. **`/ultrareview`** per epic decision D-A, then open PR with `Closes #<issue>`.
+
+---
+
+## Decisions to surface
+
+- **Draft grades — DEFER.** No web player-values / FantasyCalc service exists (`services/` has no `player-values`, `fantasycalc`, or `grade` source). Porting `DraftGradeCalculator` would require building that values pipeline first — out of proportion for s4. Ship Recap as markdown-only; file a follow-up (`s4b-draft-grades`) gated on a values service. Note the gap in the Recap empty/footer.
+- **Traded picks — PORT.** `LeagueService.getTradedPicks` already hits Sleeper `/league/{id}/traded_picks` (`league.service.ts:130`). Port the iOS per-round ownership override in full; no backend gap.
+- **Sub-tab routing — NESTED ROUTES.** Use `/draft-history/:year/{live|picks|recap|mocks}` for bookmarkability, consistent with s3's per-route split. Reject in-component tab state (loses deep links).
+- **Live polling — PORT (5s/30s).** The picks endpoint exists (`getDraftPicks`). Port the iOS cadence via RxJS `interval` + `switchMap` + `takeUntilDestroyed`; stop polling when status is complete.
+
+---
+
+## Risks / tradeoffs
+
+- **`traded_picks` correctness.** Endpoint exists but the slot→roster→owner mapping is subtle (keyed by original roster, not slot). _Mitigation:_ port the iOS logic verbatim; test against a season with a known traded pick.
+- **No FantasyCalc values on web.** Recap ships without grades — visible parity gap vs iOS. _Mitigation:_ explicit follow-up stub; note in UI.
+- **Live polling cost.** A 5s poll runs only while a draft is `drafting` and the tab is mounted. _Mitigation:_ stop on complete, `takeUntilDestroyed` on navigate-away; do not poll past seasons.
+
+---
+
+## Open questions
+
+- [ ] Recap report → year matching: does the `postDraft` report's `period`/`season` reliably encode the draft year, or do we match on `createdAt`? Confirm against a real `postDraft` row before wiring step 4.
+- [ ] Year switcher placement on mobile: shared chip row above the sub-tab bar, or fold the year into a dropdown when sub-tabs crowd the width?
 
 ---
 
 ## Success criteria
 
-- `/draft` (or equivalent) shows a year switcher; current-season view has Live / Mocks / Recap sub-tabs; past-season views have Picks / Recap.
-- Live sub-tab renders the same data the current `draft-history` page renders today.
-- Past-season Picks renders read-only picks per year.
-- Mocks sub-tab renders an explicit "deferred" placeholder (decision pending — see open questions).
-- Deep linking to a specific year + sub-tab works.
+1. `/draft-history` redirects to the current season's `live` sub-tab; a year switcher lists all seasons from the league chain.
+2. Current season shows Live / Mocks / Recap; past seasons show Picks / Recap; switching years resets to the mode default.
+3. Live renders both rounds-list and board-grid, with a working All/My Picks toggle and a live countdown.
+4. Traded picks display the correct current owner per round in both Live render modes.
+5. While a draft is `drafting`, picks populate without a manual refresh and polling stops when complete.
+6. Recap renders the stored `postDraft` report as styled markdown; Mocks renders stored `mock` reports read-only (gated for non-admins).
+7. Deep linking to `/draft-history/:year/:subtab` works on refresh; `selected-*` league mode is unregressed.
 
 ---
 
 ## Next step
 
-Run `/plan s4-draft-tab-restructure` to expand this skeleton into implementation-level detail.
+```
+/execute s4-draft-tab-restructure
+```

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -277,8 +277,49 @@ const routes: Routes = [
   // Account setup (authenticated)
   { path: 'link-sleeper', component: LinkSleeperComponent, canActivate: [AuthGuard] },
 
-  // League History (authenticated)
+  // Draft History (authenticated) — s4: per-year shell with nested sub-tab routes
+  // URL scheme: /draft-history/:year/{live|picks|recap|mocks}
+  // DraftHistoryComponent is the shell (year chips + sub-tab bar + router-outlet).
+  // Root /draft-history has no children — DraftHistoryComponent.ngOnInit redirects to
+  // /draft-history/:currentSeason/live (or picks for past seasons).
   { path: 'draft-history', component: DraftHistoryComponent, canActivate: [AuthGuard] },
+  {
+    path: 'draft-history/:year',
+    component: DraftHistoryComponent,
+    canActivate: [AuthGuard],
+    children: [
+      {
+        path: 'live',
+        loadComponent: () =>
+          import('./pages/draft-history/live/draft-live.component').then(
+            (m) => m.DraftLiveComponent,
+          ),
+      },
+      {
+        path: 'picks',
+        loadComponent: () =>
+          import('./pages/draft-history/picks/draft-picks.component').then(
+            (m) => m.DraftPicksComponent,
+          ),
+      },
+      {
+        path: 'recap',
+        loadComponent: () =>
+          import('./pages/draft-history/recap/draft-recap.component').then(
+            (m) => m.DraftRecapComponent,
+          ),
+      },
+      {
+        path: 'mocks',
+        loadComponent: () =>
+          import('./pages/draft-history/mocks/draft-mocks.component').then(
+            (m) => m.DraftMocksComponent,
+          ),
+      },
+      // Default sub-tab: DraftHistoryComponent.ngOnInit redirects per isCurrentSeason
+      { path: '', redirectTo: 'live', pathMatch: 'full' },
+    ],
+  },
   { path: 'matchup-history', component: MatchupHistoryComponent, canActivate: [AuthGuard] },
 
   // Catch-all

--- a/src/app/pages/draft-history/draft-history.component.html
+++ b/src/app/pages/draft-history/draft-history.component.html
@@ -4,86 +4,38 @@
   <div class="draft-container" *ngIf="!loading">
     <!-- Header -->
     <div class="page-header">
-      <button class="back-btn" (click)="goBack()">
-        <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
-          <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
-        </svg>
-        Back
-      </button>
       <h1 class="page-title">Draft History</h1>
       <p class="league-name">{{ leagueName }}</p>
     </div>
 
-    <!-- Season Selector -->
-    <div class="season-selector" *ngIf="availableSeasons.length > 0">
+    <!-- Year switcher -->
+    <div class="year-selector" *ngIf="availableSeasons.length > 0">
       <button
-        *ngFor="let season of availableSeasons"
-        class="season-btn"
-        [class.active]="season === selectedSeason"
-        (click)="selectSeason(season)"
+        *ngFor="let year of availableSeasons"
+        class="year-btn"
+        [class.active]="year === selectedYear"
+        (click)="selectYear(year)"
       >
-        {{ season }}
+        {{ year }}
+        <span class="season-badge" *ngIf="isCurrentSeason(year)">Current</span>
       </button>
     </div>
 
-    <!-- Empty State -->
-    <div class="empty-state" *ngIf="draftRounds.length === 0 && !loading">
-      <p>No draft history found for this league.</p>
-      <p class="hint">Draft picks will appear here once the draft is complete.</p>
-    </div>
+    <!-- Sub-tab bar -->
+    <nav class="subtab-bar" *ngIf="selectedYear">
+      <a
+        *ngFor="let tab of subTabsForYear(selectedYear)"
+        class="subtab-link"
+        [routerLink]="['/draft-history', selectedYear, tab]"
+        routerLinkActive="active"
+      >
+        {{ subTabLabel(tab) }}
+      </a>
+    </nav>
 
-    <!-- Draft Rounds -->
-    <div class="draft-rounds" *ngIf="draftRounds.length > 0">
-      <div class="round-section" *ngFor="let round of draftRounds">
-        <h2 class="round-title">Round {{ round.round }}</h2>
-        
-        <div class="picks-grid">
-          <div
-            class="pick-card"
-            *ngFor="let pick of round.picks"
-            [ngStyle]="getTeamStyle(pick.player_team)"
-          >
-            <!-- Pick Number -->
-            <div class="pick-number">{{ pick.pick_no }}</div>
-            
-            <!-- Player Info -->
-            <div class="player-section">
-              <img
-                [src]="'https://sleepercdn.com/content/nfl/players/thumb/' + pick.player_id + '.jpg'"
-                (error)="$any($event.target).src = 'assets/img/nfl.png'"
-                alt="{{ pick.player_name }}"
-                class="player-pic"
-              />
-              <div class="player-details">
-                <h3 class="player-name">{{ pick.player_name }}</h3>
-                <div class="player-meta">
-                  <span class="position-badge" [ngClass]="getPositionClass(pick.player_position)">
-                    {{ pick.player_position }}
-                  </span>
-                  <span class="team-abbr">{{ pick.player_team || 'FA' }}</span>
-                </div>
-              </div>
-              <img
-                *ngIf="pick.player_team"
-                [src]="'https://sleepercdn.com/images/team_logos/nfl/' + pick.player_team.toLowerCase() + '.png'"
-                alt="{{ pick.player_team }}"
-                class="team-logo"
-              />
-            </div>
-
-            <!-- Picked By -->
-            <div class="picked-by">
-              <span class="picked-label">Picked by:</span>
-              <span class="team-name">{{ pick.picked_by_team_name || pick.picked_by_username }}</span>
-            </div>
-
-            <!-- Keeper Badge -->
-            <div class="keeper-badge" *ngIf="pick.is_keeper">
-              KEEPER
-            </div>
-          </div>
-        </div>
-      </div>
+    <!-- Sub-tab content -->
+    <div class="subtab-content" *ngIf="selectedYear">
+      <router-outlet></router-outlet>
     </div>
   </div>
 </div>

--- a/src/app/pages/draft-history/draft-history.component.scss
+++ b/src/app/pages/draft-history/draft-history.component.scss
@@ -17,36 +17,6 @@
 .page-header {
   text-align: center;
   margin-bottom: $spacing-xl;
-  position: relative;
-
-  .back-btn {
-    position: absolute;
-    left: 0;
-    top: 0;
-    display: flex;
-    align-items: center;
-    gap: $spacing-xs;
-    background: transparent;
-    border: 1px solid $surface-light;
-    color: $text-secondary;
-    padding: 8px 16px;
-    margin: 0;
-    border-radius: $radius-md;
-    cursor: pointer;
-    font-size: $text-sm;
-    transition: all $transition-base;
-
-    &:hover {
-      border-color: $champion-gold;
-      color: $champion-gold;
-      background: transparent;
-    }
-
-    svg {
-      width: 18px;
-      height: 18px;
-    }
-  }
 
   .page-title {
     font-family: $font-display;
@@ -63,16 +33,19 @@
   }
 }
 
-// Season Selector
-.season-selector {
+// Year Selector
+.year-selector {
   display: flex;
   justify-content: center;
   gap: $spacing-sm;
-  margin-bottom: $spacing-xl;
+  margin-bottom: $spacing-lg;
   flex-wrap: wrap;
 }
 
-.season-btn {
+.year-btn {
+  display: flex;
+  align-items: center;
+  gap: $spacing-xs;
   background: rgba($dark-navy, 0.6);
   color: $text-secondary;
   border: 1px solid $surface-light;
@@ -97,188 +70,57 @@
   }
 }
 
-// Empty State
-.empty-state {
-  text-align: center;
-  padding: $spacing-2xl;
-  background: $card-gradient;
-  border-radius: $radius-lg;
-  border: 1px solid rgba($surface-light, 0.2);
-
-  p {
-    font-size: $text-lg;
-    color: $text-secondary;
-    margin: 0;
-  }
-
-  .hint {
-    font-size: $text-sm;
-    color: $text-muted;
-    margin-top: $spacing-sm;
-  }
-}
-
-// Draft Rounds
-.draft-rounds {
-  display: flex;
-  flex-direction: column;
-  gap: $spacing-xl;
-}
-
-.round-section {
-  background: $card-gradient;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba($surface-light, 0.2);
-  border-radius: $radius-lg;
-  padding: $spacing-lg;
-}
-
-.round-title {
-  font-family: $font-display;
-  font-size: 1.5rem;
-  letter-spacing: 0.05em;
+.season-badge {
+  font-size: $text-xs;
+  background: rgba($champion-gold, 0.2);
   color: $champion-gold;
-  margin-bottom: $spacing-lg;
-  padding-bottom: $spacing-sm;
-  border-bottom: 2px solid rgba($champion-gold, 0.3);
+  border-radius: $radius-sm;
+  padding: 1px 6px;
+  font-family: $font-body;
+  font-weight: 500;
+
+  .year-btn.active & {
+    background: rgba($deep-navy, 0.3);
+    color: $deep-navy;
+  }
 }
 
-// Picks Grid
-.picks-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: $spacing-md;
+// Sub-tab bar
+.subtab-bar {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid rgba($surface-light, 0.4);
+  margin-bottom: $spacing-xl;
+  overflow-x: auto;
 }
 
-.pick-card {
-  position: relative;
-  background: rgba($dark-navy, 0.6);
-  border: 1px solid rgba($surface-light, 0.3);
-  border-radius: $radius-lg;
-  padding: $spacing-md;
+.subtab-link {
+  padding: 12px 24px;
+  font-size: $text-sm;
+  font-weight: 600;
+  color: $text-secondary;
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
   transition: all $transition-base;
+  white-space: nowrap;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-family: $font-mono;
 
   &:hover {
-    transform: translateY(-4px);
-    box-shadow: $shadow-lg;
-    border-color: rgba($champion-gold, 0.4);
-  }
-}
-
-.pick-number {
-  position: absolute;
-  top: $spacing-sm;
-  left: $spacing-sm;
-  width: 32px;
-  height: 32px;
-  background: $gold-accent;
-  color: $deep-navy;
-  border-radius: $radius-full;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  font-size: $text-sm;
-  font-family: $font-mono;
-}
-
-.player-section {
-  display: flex;
-  align-items: center;
-  gap: $spacing-sm;
-  margin-left: 40px;
-  margin-bottom: $spacing-sm;
-}
-
-.player-pic {
-  width: 50px;
-  height: 50px;
-  border-radius: $radius-full;
-  object-fit: cover;
-  border: 2px solid $surface-light;
-}
-
-.player-details {
-  flex: 1;
-  min-width: 0;
-
-  .player-name {
-    font-size: $text-base;
-    font-weight: 600;
-    margin: 0;
     color: $text-primary;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    background: rgba($surface-light, 0.2);
   }
 
-  .player-meta {
-    display: flex;
-    align-items: center;
-    gap: $spacing-sm;
-    margin-top: 4px;
+  &.active {
+    color: $champion-gold;
+    border-bottom-color: $champion-gold;
   }
 }
 
-.position-badge {
-  font-size: $text-xs;
-  font-weight: 700;
-  padding: 2px 8px;
-  border-radius: $radius-sm;
-  text-transform: uppercase;
-
-  &.pos-qb { background: #e74c3c; color: white; }
-  &.pos-rb { background: #27ae60; color: white; }
-  &.pos-wr { background: #3498db; color: white; }
-  &.pos-te { background: #f39c12; color: white; }
-  &.pos-k { background: #9b59b6; color: white; }
-  &.pos-def { background: #34495e; color: white; }
-}
-
-.team-abbr {
-  font-size: $text-xs;
-  color: $text-secondary;
-  font-family: $font-mono;
-}
-
-.team-logo {
-  width: 32px;
-  height: 32px;
-  object-fit: contain;
-  flex-shrink: 0;
-}
-
-.picked-by {
-  display: flex;
-  align-items: center;
-  gap: $spacing-xs;
-  padding-top: $spacing-sm;
-  border-top: 1px solid rgba($surface-light, 0.2);
-  margin-top: $spacing-sm;
-
-  .picked-label {
-    font-size: $text-xs;
-    color: $text-muted;
-  }
-
-  .team-name {
-    font-size: $text-sm;
-    color: $text-primary;
-    font-weight: 500;
-  }
-}
-
-.keeper-badge {
-  position: absolute;
-  top: $spacing-sm;
-  right: $spacing-sm;
-  background: $steel-blue;
-  color: white;
-  font-size: $text-xs;
-  font-weight: 700;
-  padding: 2px 8px;
-  border-radius: $radius-sm;
-  text-transform: uppercase;
+.subtab-content {
+  min-height: 200px;
 }
 
 // Mobile
@@ -287,31 +129,21 @@
     padding: $spacing-md;
   }
 
-  .page-header {
-    .back-btn {
-      position: relative;
-      margin-bottom: $spacing-md;
-    }
-
-    .page-title {
-      font-size: 2rem;
-    }
+  .page-header .page-title {
+    font-size: 2rem;
   }
 
-  .season-selector {
+  .year-selector {
     gap: $spacing-xs;
   }
 
-  .season-btn {
+  .year-btn {
     padding: 8px 16px;
     font-size: $text-sm;
   }
 
-  .picks-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .round-section {
-    padding: $spacing-md;
+  .subtab-link {
+    padding: 10px 16px;
+    font-size: $text-xs;
   }
 }

--- a/src/app/pages/draft-history/draft-history.component.ts
+++ b/src/app/pages/draft-history/draft-history.component.ts
@@ -1,45 +1,37 @@
 import { Component, OnInit } from '@angular/core'
-import { ActivatedRoute, Router } from '@angular/router'
+import { ActivatedRoute, Router, RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router'
 import { switchMap, take } from 'rxjs'
 import { LeagueService } from 'src/app/services/league.service'
-import { LeagueHistoryService, DraftHistoryRecord } from 'src/app/services/league-history.service'
+import { LeagueHistoryService } from 'src/app/services/league-history.service'
 import { ToastService } from 'src/app/services/toast.service'
-import { TEAM_COLORS } from 'src/app/constants/team-colors'
-import { LoaderComponent } from '../../components/loader/loader.component';
-import { NgIf, NgFor, NgStyle, NgClass } from '@angular/common';
+import { LoaderComponent } from '../../components/loader/loader.component'
+import { NgIf, NgFor, NgClass } from '@angular/common'
+import { getCurrentSeason } from 'src/app/constants/season'
 
-interface DraftRound {
-  round: number
-  picks: DraftHistoryRecord[]
-}
+type SubTab = 'live' | 'picks' | 'recap' | 'mocks'
 
 @Component({
-    selector: 'app-draft-history',
-    templateUrl: './draft-history.component.html',
-    styleUrls: ['./draft-history.component.scss'],
-    standalone: true,
-    imports: [LoaderComponent, NgIf, NgFor, NgStyle, NgClass]
+  selector: 'app-draft-history',
+  templateUrl: './draft-history.component.html',
+  styleUrls: ['./draft-history.component.scss'],
+  standalone: true,
+  imports: [LoaderComponent, NgIf, NgFor, NgClass, RouterOutlet, RouterLink, RouterLinkActive],
 })
 export class DraftHistoryComponent implements OnInit {
   loading = false
   leagueName = ''
   leagueId = ''
-  
-  // Data
-  allDrafts: DraftHistoryRecord[] = []
+
   availableSeasons: string[] = []
-  selectedSeason: string = ''
-  draftRounds: DraftRound[] = []
-  
-  // View options
-  viewMode: 'round' | 'team' | 'position' = 'round'
-  
+  selectedYear = ''
+  readonly currentSeason = getCurrentSeason()
+
   constructor(
     private leagueService: LeagueService,
     private historyService: LeagueHistoryService,
     private toastService: ToastService,
     private router: Router,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) {}
 
   ngOnInit(): void {
@@ -52,27 +44,46 @@ export class DraftHistoryComponent implements OnInit {
 
     this.leagueName = league.getDisplayName()
     this.leagueId = league.getId()
-    this.loadDraftHistory()
+
+    // Sync selected year from route :year param
+    const yearParam = this.route.snapshot.paramMap.get('year')
+    if (yearParam) {
+      this.selectedYear = yearParam
+    }
+
+    // Subscribe to route param changes so year switcher stays in sync on navigation
+    this.route.params.subscribe(params => {
+      if (params['year']) {
+        this.selectedYear = params['year']
+      }
+    })
+
+    this.loadSeasons()
   }
 
-  loadDraftHistory(): void {
+  loadSeasons(): void {
     this.loading = true
 
     this.leagueService.getLeagueChain(this.leagueId).pipe(
       switchMap(chain => this.historyService.getDraftHistoryFromChain(chain)),
-      take(1)
+      take(1),
     ).subscribe({
       next: (drafts) => {
-        this.allDrafts = drafts
-
-        // Get unique seasons
         this.availableSeasons = [...new Set(drafts.map(d => d.season))]
           .sort((a, b) => parseInt(b) - parseInt(a))
 
-        // Default to most recent season
         if (this.availableSeasons.length > 0) {
-          this.selectedSeason = this.availableSeasons[0]
-          this.filterBySeason()
+          // If no year selected yet (root /draft-history), navigate to current season default
+          if (!this.selectedYear) {
+            const defaultYear = this.availableSeasons[0]
+            const defaultSubTab = this.defaultSubTab(defaultYear)
+            this.router.navigate(['/draft-history', defaultYear, defaultSubTab], { replaceUrl: true })
+          } else if (!this.availableSeasons.includes(this.selectedYear)) {
+            // Requested year not in list — fall back to most recent
+            const fallback = this.availableSeasons[0]
+            this.selectedYear = fallback
+            this.router.navigate(['/draft-history', fallback, this.defaultSubTab(fallback)], { replaceUrl: true })
+          }
         }
 
         this.loading = false
@@ -80,61 +91,37 @@ export class DraftHistoryComponent implements OnInit {
       error: () => {
         this.toastService.showNegativeToast('Error loading draft history')
         this.loading = false
-      }
+      },
     })
   }
 
-  filterBySeason(): void {
-    const seasonDrafts = this.allDrafts.filter(d => d.season === this.selectedSeason)
-    this.groupByRound(seasonDrafts)
+  defaultSubTab(year: string): SubTab {
+    return year === this.currentSeason ? 'live' : 'picks'
   }
 
-  groupByRound(drafts: DraftHistoryRecord[]): void {
-    const roundMap = new Map<number, DraftHistoryRecord[]>()
-    
-    drafts.forEach(pick => {
-      if (!roundMap.has(pick.round)) {
-        roundMap.set(pick.round, [])
-      }
-      roundMap.get(pick.round)!.push(pick)
-    })
-
-    this.draftRounds = Array.from(roundMap.entries())
-      .map(([round, picks]) => ({
-        round,
-        picks: picks.sort((a, b) => a.pick_no - b.pick_no)
-      }))
-      .sort((a, b) => a.round - b.round)
+  isCurrentSeason(year: string): boolean {
+    return year === this.currentSeason
   }
 
-  selectSeason(season: string): void {
-    this.selectedSeason = season
-    this.filterBySeason()
+  selectYear(year: string): void {
+    this.selectedYear = year
+    const subTab = this.defaultSubTab(year)
+    this.router.navigate(['/draft-history', year, subTab])
   }
 
-  getTeamStyle(team: string | undefined) {
-    if (!team) return { backgroundColor: '#2a2a2a' }
-    const colors = TEAM_COLORS[team.toLowerCase()]
-    return colors
-      ? { background: `linear-gradient(135deg, ${colors.primary}40, ${colors.secondary}40)` }
-      : { backgroundColor: '#2a2a2a' }
+  subTabsForYear(year: string): SubTab[] {
+    return year === this.currentSeason
+      ? ['live', 'mocks', 'recap']
+      : ['picks', 'recap']
   }
 
-  getPositionClass(position: string): string {
-    const posMap: Record<string, string> = {
-      'QB': 'pos-qb',
-      'RB': 'pos-rb',
-      'WR': 'pos-wr',
-      'TE': 'pos-te',
-      'K': 'pos-k',
-      'DEF': 'pos-def'
+  subTabLabel(tab: SubTab): string {
+    const labels: Record<SubTab, string> = {
+      live: 'Live',
+      picks: 'Picks',
+      recap: 'Recap',
+      mocks: 'Mocks',
     }
-    return posMap[position] || ''
-  }
-
-  goBack(): void {
-    this.router.navigate(['/my-league'], {
-      queryParams: { leagueId: this.leagueId, view: 'league' }
-    })
+    return labels[tab]
   }
 }

--- a/src/app/pages/draft-history/live/draft-live.component.html
+++ b/src/app/pages/draft-history/live/draft-live.component.html
@@ -1,0 +1,138 @@
+<div class="draft-live">
+  <app-loader [loading]="loading"></app-loader>
+
+  <div *ngIf="!loading">
+    <!-- No draft found -->
+    <div class="empty-state" *ngIf="!draft">
+      <p>No draft found for {{ year }}.</p>
+    </div>
+
+    <div *ngIf="draft">
+      <!-- Header card: status + countdown -->
+      <div class="live-header" [class]="'status-' + draft.status">
+        <div class="header-main">
+          <span class="status-badge" [class]="'badge-' + draft.status">{{ draftStatusLabel }}</span>
+          <h2 class="draft-name">{{ draft.metadata?.name || year + ' Draft' }}</h2>
+        </div>
+        <div class="countdown" *ngIf="countdown">{{ countdown }}</div>
+      </div>
+
+      <!-- Controls bar -->
+      <div class="controls-bar">
+        <!-- All / My Picks filter -->
+        <div class="chip-group">
+          <button
+            class="chip"
+            [class.active]="pickFilter === 'all'"
+            (click)="setPickFilter('all')"
+          >All Picks</button>
+          <button
+            class="chip"
+            [class.active]="pickFilter === 'mine'"
+            (click)="setPickFilter('mine')"
+          >My Picks</button>
+        </div>
+
+        <!-- Rounds / Board toggle -->
+        <div class="chip-group">
+          <button
+            class="chip"
+            [class.active]="viewMode === 'rounds'"
+            (click)="setViewMode('rounds')"
+          >Rounds</button>
+          <button
+            class="chip"
+            [class.active]="viewMode === 'board'"
+            (click)="setViewMode('board')"
+          >Board</button>
+        </div>
+      </div>
+
+      <!-- ============ ROUNDS LIST VIEW ============ -->
+      <div class="rounds-list" *ngIf="viewMode === 'rounds'">
+        <div class="round-block" *ngFor="let round of filteredRounds">
+          <h3 class="round-heading">Round {{ round.round }}</h3>
+          <div class="round-rows">
+            <div
+              class="pick-row"
+              *ngFor="let cell of round.cells"
+              [class.pick-made]="cell.pick !== null"
+              [class.my-pick]="cell.isMine"
+            >
+              <!-- Slot / pick number -->
+              <span class="pick-slot">{{ cell.pick ? cell.pick.pick_no : (round.round - 1) * teamCount + cell.slot }}</span>
+
+              <!-- Player info if pick made -->
+              <ng-container *ngIf="cell.pick">
+                <img
+                  class="player-thumb"
+                  [src]="'https://sleepercdn.com/content/nfl/players/thumb/' + cell.pick.player_id + '.jpg'"
+                  (error)="$any($event.target).src = 'assets/img/nfl.png'"
+                  alt="{{ cell.pick.metadata?.first_name }} {{ cell.pick.metadata?.last_name }}"
+                />
+                <div class="pick-info">
+                  <span class="player-name">
+                    {{ cell.pick.metadata?.first_name }} {{ cell.pick.metadata?.last_name }}
+                  </span>
+                  <span class="player-pos-team">
+                    <span class="pos-badge" [class]="'pos-' + (cell.pick.metadata?.position | lowercase)">
+                      {{ cell.pick.metadata?.position }}
+                    </span>
+                    {{ cell.pick.metadata?.team || 'FA' }}
+                  </span>
+                </div>
+              </ng-container>
+
+              <!-- Empty slot -->
+              <div class="empty-pick" *ngIf="!cell.pick">
+                <span class="owner-name">{{ cell.ownerName }}</span>
+              </div>
+
+              <!-- My pick indicator -->
+              <span class="my-badge" *ngIf="cell.isMine">Mine</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Empty state for My Picks filter -->
+        <div class="empty-state" *ngIf="filteredRounds.length === 0 && pickFilter === 'mine'">
+          <p>No picks made yet.</p>
+        </div>
+      </div>
+
+      <!-- ============ BOARD GRID VIEW ============ -->
+      <div class="board-wrapper" *ngIf="viewMode === 'board'">
+        <div class="board-scroll">
+          <table class="board-table">
+            <thead>
+              <tr>
+                <th class="round-col">Rd</th>
+                <th *ngFor="let slot of slots" class="slot-col">{{ slot }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let round of rounds">
+                <td class="round-label">{{ round.round }}</td>
+                <td
+                  *ngFor="let cell of round.cells"
+                  class="board-cell"
+                  [class.pick-made]="cell.pick !== null"
+                  [class.my-pick]="cell.isMine"
+                  [class.dimmed]="isCellDimmed(cell)"
+                >
+                  <ng-container *ngIf="cell.pick">
+                    <span class="cell-name">{{ cell.pick.metadata?.last_name || cell.pick.metadata?.first_name }}</span>
+                    <span class="cell-pos" [class]="'pos-' + (cell.pick.metadata?.position | lowercase)">
+                      {{ cell.pick.metadata?.position }}
+                    </span>
+                  </ng-container>
+                  <span class="cell-owner" *ngIf="!cell.pick">{{ cell.ownerName }}</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/draft-history/live/draft-live.component.scss
+++ b/src/app/pages/draft-history/live/draft-live.component.scss
@@ -1,0 +1,403 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+
+.draft-live {
+  min-height: 200px;
+}
+
+// Header card
+.live-header {
+  background: $card-gradient;
+  border: 1px solid rgba($surface-light, 0.3);
+  border-radius: $radius-lg;
+  padding: $spacing-lg;
+  margin-bottom: $spacing-lg;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-md;
+  flex-wrap: wrap;
+
+  &.status-drafting {
+    border-color: rgba($champion-gold, 0.5);
+    background: linear-gradient(
+      135deg,
+      rgba($champion-gold, 0.05) 0%,
+      rgba(12, 22, 18, 0.97) 50%,
+    );
+  }
+
+  &.status-complete {
+    border-color: rgba($success-green, 0.3);
+  }
+}
+
+.header-main {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-xs;
+}
+
+.status-badge {
+  display: inline-block;
+  font-size: $text-xs;
+  font-weight: 700;
+  font-family: $font-mono;
+  padding: 2px 10px;
+  border-radius: $radius-full;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+
+  &.badge-drafting {
+    background: rgba($champion-gold, 0.2);
+    color: $champion-gold;
+    border: 1px solid rgba($champion-gold, 0.5);
+  }
+
+  &.badge-pre_draft {
+    background: rgba($text-secondary, 0.1);
+    color: $text-secondary;
+    border: 1px solid rgba($surface-light, 0.4);
+  }
+
+  &.badge-complete {
+    background: rgba($success-green, 0.15);
+    color: $success-green;
+    border: 1px solid rgba($success-green, 0.3);
+  }
+
+  &.badge-paused {
+    background: rgba($error-red, 0.15);
+    color: $error-red;
+    border: 1px solid rgba($error-red, 0.3);
+  }
+}
+
+.draft-name {
+  font-family: $font-display;
+  font-size: 1.5rem;
+  letter-spacing: 0.04em;
+  color: $text-primary;
+  margin: 0;
+}
+
+.countdown {
+  font-family: $font-mono;
+  font-size: $text-lg;
+  font-weight: 600;
+  color: $champion-gold;
+  text-align: right;
+}
+
+// Controls bar
+.controls-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-md;
+  margin-bottom: $spacing-xl;
+  flex-wrap: wrap;
+}
+
+.chip-group {
+  display: flex;
+  gap: 0;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-xl;
+  overflow: hidden;
+}
+
+.chip {
+  padding: 8px 20px;
+  background: transparent;
+  border: none;
+  color: $text-secondary;
+  font-size: $text-sm;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all $transition-fast;
+  font-family: $font-mono;
+
+  &.active {
+    background: $gold-accent;
+    color: $deep-navy;
+  }
+
+  &:hover:not(.active) {
+    background: rgba($surface-light, 0.3);
+    color: $text-primary;
+  }
+}
+
+// Empty state
+.empty-state {
+  text-align: center;
+  padding: $spacing-2xl;
+  background: $card-gradient;
+  border-radius: $radius-lg;
+  border: 1px solid rgba($surface-light, 0.2);
+
+  p {
+    font-size: $text-lg;
+    color: $text-secondary;
+    margin: 0;
+  }
+}
+
+// ===== ROUNDS LIST VIEW =====
+.rounds-list {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-xl;
+}
+
+.round-block {
+  background: $card-gradient;
+  border: 1px solid rgba($surface-light, 0.2);
+  border-radius: $radius-lg;
+  overflow: hidden;
+}
+
+.round-heading {
+  font-family: $font-display;
+  font-size: 1.2rem;
+  letter-spacing: 0.05em;
+  color: $champion-gold;
+  padding: $spacing-md $spacing-lg;
+  border-bottom: 1px solid rgba($surface-light, 0.2);
+  margin: 0;
+}
+
+.round-rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.pick-row {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  padding: $spacing-sm $spacing-lg;
+  border-bottom: 1px solid rgba($surface-light, 0.1);
+  min-height: 56px;
+  transition: background $transition-fast;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &.my-pick {
+    background: rgba($champion-gold, 0.05);
+    border-left: 3px solid $champion-gold;
+  }
+
+  &:not(.pick-made) {
+    opacity: 0.6;
+  }
+}
+
+.pick-slot {
+  width: 36px;
+  height: 36px;
+  border-radius: $radius-full;
+  background: rgba($surface-light, 0.3);
+  color: $text-secondary;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: $font-mono;
+  font-size: $text-sm;
+  font-weight: 700;
+  flex-shrink: 0;
+
+  .pick-made & {
+    background: $gold-accent;
+    color: $deep-navy;
+  }
+}
+
+.player-thumb {
+  width: 40px;
+  height: 40px;
+  border-radius: $radius-full;
+  object-fit: cover;
+  border: 2px solid rgba($surface-light, 0.4);
+  flex-shrink: 0;
+}
+
+.pick-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+
+  .player-name {
+    font-size: $text-sm;
+    font-weight: 600;
+    color: $text-primary;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .player-pos-team {
+    display: flex;
+    align-items: center;
+    gap: $spacing-xs;
+    font-size: $text-xs;
+    color: $text-secondary;
+  }
+}
+
+.empty-pick {
+  flex: 1;
+
+  .owner-name {
+    font-size: $text-sm;
+    color: $text-muted;
+    font-style: italic;
+  }
+}
+
+.my-badge {
+  font-size: $text-xs;
+  font-weight: 700;
+  background: rgba($champion-gold, 0.2);
+  color: $champion-gold;
+  border: 1px solid rgba($champion-gold, 0.4);
+  border-radius: $radius-full;
+  padding: 2px 8px;
+  flex-shrink: 0;
+}
+
+// Position badges (rounds list + board)
+.pos-badge,
+.cell-pos {
+  display: inline-block;
+  font-size: $text-xs;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: $radius-sm;
+  text-transform: uppercase;
+
+  &.pos-qb { background: #e74c3c; color: white; }
+  &.pos-rb { background: #27ae60; color: white; }
+  &.pos-wr { background: #3498db; color: white; }
+  &.pos-te { background: #f39c12; color: white; }
+  &.pos-k  { background: #9b59b6; color: white; }
+  &.pos-def { background: #34495e; color: white; }
+}
+
+// ===== BOARD GRID VIEW =====
+.board-wrapper {
+  overflow: hidden;
+  border-radius: $radius-lg;
+  border: 1px solid rgba($surface-light, 0.3);
+}
+
+.board-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.board-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 600px;
+
+  th, td {
+    padding: 6px 8px;
+    text-align: center;
+    border: 1px solid rgba($surface-light, 0.15);
+    font-size: $text-xs;
+  }
+
+  thead th {
+    background: rgba($dark-navy, 0.8);
+    color: $text-secondary;
+    font-family: $font-mono;
+    font-weight: 700;
+    font-size: $text-xs;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+  }
+
+  .round-col, .round-label {
+    width: 36px;
+    min-width: 36px;
+    background: rgba($dark-navy, 0.6);
+    color: $champion-gold;
+    font-family: $font-mono;
+    font-weight: 700;
+  }
+
+  .slot-col {
+    min-width: 80px;
+  }
+}
+
+.board-cell {
+  vertical-align: top;
+  background: rgba($dark-navy, 0.4);
+  min-height: 52px;
+  transition: all $transition-fast;
+  text-align: center;
+  padding: 6px;
+
+  &.pick-made {
+    background: rgba($surface-light, 0.2);
+  }
+
+  &.my-pick {
+    background: rgba($champion-gold, 0.1);
+    border-color: rgba($champion-gold, 0.3) !important;
+  }
+
+  &.dimmed {
+    opacity: 0.3;
+  }
+}
+
+.cell-name {
+  font-size: $text-xs;
+  font-weight: 600;
+  color: $text-primary;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 72px;
+  display: block;
+}
+
+.cell-owner {
+  font-size: 10px;
+  color: $text-muted;
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 72px;
+  display: block;
+}
+
+@media (max-width: 768px) {
+  .controls-bar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .live-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .countdown {
+    text-align: left;
+  }
+
+  .pick-row {
+    padding: $spacing-sm $spacing-md;
+  }
+}

--- a/src/app/pages/draft-history/live/draft-live.component.ts
+++ b/src/app/pages/draft-history/live/draft-live.component.ts
@@ -1,0 +1,369 @@
+import { Component, OnInit, DestroyRef, inject } from '@angular/core'
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
+import { ActivatedRoute, Router } from '@angular/router'
+import { AsyncPipe, NgIf, NgFor, NgClass, LowerCasePipe } from '@angular/common'
+import { interval, switchMap, of, forkJoin, BehaviorSubject, Observable } from 'rxjs'
+import { map, take } from 'rxjs/operators'
+import { LeagueService, TradedPick } from 'src/app/services/league.service'
+import { DraftService } from 'src/app/services/draft.service'
+import { DraftModel } from 'src/app/models/draft.model'
+import { DraftPick } from 'src/app/models/draft.interface'
+import { User } from 'src/app/models/user.interface'
+import { Roster } from 'src/app/models/roster.interface'
+import { LoaderComponent } from '../../../components/loader/loader.component'
+import { SupabaseService } from 'src/app/services/supabase.service'
+
+type ViewMode = 'rounds' | 'board'
+type PickFilter = 'all' | 'mine'
+
+interface LiveCell {
+  round: number
+  slot: number
+  /** Display name of the team that owns this pick in this round (traded_picks applied). */
+  ownerName: string
+  pick: DraftPick | null
+  isMine: boolean
+}
+
+interface LiveRound {
+  round: number
+  cells: LiveCell[]
+}
+
+/**
+ * Live sub-tab — ports iOS LiveDraftView.
+ *
+ * Renders a live draft board for the current season:
+ *   - Controls bar: All/My Picks chip + Rounds/Board view toggle
+ *   - Countdown header: ms-level countdown via RxJS interval(1000)
+ *   - Rounds list: picks in round rows, filterable to My Picks
+ *   - Board grid: slot columns × round rows, dimmed for non-mine cells (My filter)
+ *
+ * Traded picks: fetches /league/:id/traded_picks, builds per-round ownership
+ * override map. Port of iOS liveTeamsBySlotByRound.
+ *
+ * Polling: 5s while drafting, 30s while pre_draft, stops on complete.
+ * Uses interval + switchMap + takeUntilDestroyed.
+ */
+@Component({
+  selector: 'app-draft-live',
+  templateUrl: './draft-live.component.html',
+  styleUrls: ['./draft-live.component.scss'],
+  standalone: true,
+  imports: [LoaderComponent, NgIf, NgFor, NgClass, AsyncPipe, LowerCasePipe],
+})
+export class DraftLiveComponent implements OnInit {
+  private destroyRef = inject(DestroyRef)
+
+  loading = true
+  draft: DraftModel | null = null
+  leagueId = ''
+  year = ''
+
+  // View state
+  viewMode: ViewMode = 'rounds'
+  pickFilter: PickFilter = 'all'
+
+  // Derived display data
+  rounds: LiveRound[] = []
+  slots: number[] = []
+  teamCount = 12
+
+  // Countdown
+  countdown = ''
+
+  // My Sleeper user ID (for "My Picks" filter)
+  private mySleeperUserId: string | null = null
+
+  // Base slot → team name map (from draft_order + users)
+  private baseSlotToName: Map<number, string> = new Map()
+  // Per-round override: round → (slot → teamName)
+  private slotByRound: Map<number, Map<number, string>> = new Map()
+
+  constructor(
+    private leagueService: LeagueService,
+    private draftService: DraftService,
+    private supabase: SupabaseService,
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    const league = this.leagueService.getMyLeague()
+    if (!league) {
+      this.router.navigate(['/home'])
+      return
+    }
+    this.leagueId = league.getId()
+    this.year = this.route.parent?.snapshot.paramMap.get('year') ?? ''
+
+    // Resolve my sleeper user id from profile
+    const profile = this.supabase.getProfile()
+    this.mySleeperUserId = profile?.sleeper_user_id ?? null
+
+    this.loadDraft()
+  }
+
+  private loadDraft(): void {
+    this.loading = true
+
+    forkJoin({
+      users: this.leagueService.findLeagueUsers(this.leagueId),
+      rosters: this.leagueService.findLeagueRosters(this.leagueId),
+      drafts: this.draftService.getDraftsForLeague(this.leagueId),
+      tradedPicks: this.leagueService.getTradedPicks(this.leagueId),
+    }).pipe(take(1)).subscribe({
+      next: ({ users, rosters, drafts, tradedPicks }) => {
+        // Find the draft for the current year
+        const draft = drafts.find(d => d.season === this.year) ?? drafts[0] ?? null
+        this.draft = draft
+
+        if (!draft) {
+          this.loading = false
+          return
+        }
+
+        this.teamCount = draft.settings?.teams ?? 12
+        this.slots = Array.from({ length: this.teamCount }, (_, i) => i + 1)
+
+        // Build base slot → team name map
+        this.baseSlotToName = this.buildBaseSlotMap(draft.draft_order, users, rosters)
+
+        // Build per-round slot override from traded picks
+        this.slotByRound = this.buildSlotByRound(
+          tradedPicks,
+          draft.settings?.rounds ?? 15,
+          rosters,
+          users,
+        )
+
+        // Start countdown timer
+        this.startCountdown(draft)
+
+        // Start polling
+        this.startPolling(draft)
+
+        this.loading = false
+      },
+      error: () => {
+        this.loading = false
+      },
+    })
+  }
+
+  /**
+   * Builds base slot → team display name map.
+   * draft_order is userId → slot (Sleeper API), so we invert it.
+   * Mirrors iOS liveTeamsBySlot.
+   */
+  private buildBaseSlotMap(
+    draftOrder: Record<string, number> | null,
+    users: User[],
+    rosters: Roster[],
+  ): Map<number, string> {
+    const slotToName = new Map<number, string>()
+
+    if (!draftOrder) {
+      // Fallback: no draft order recorded yet
+      return slotToName
+    }
+
+    // draftOrder: userId → slotNumber
+    Object.entries(draftOrder).forEach(([userId, slot]) => {
+      const user = users.find(u => u.user_id === userId)
+      const name =
+        (user?.metadata?.team_name as string) ||
+        user?.display_name ||
+        user?.username ||
+        `Slot ${slot}`
+      slotToName.set(slot, name)
+    })
+
+    return slotToName
+  }
+
+  /**
+   * Builds per-round slot override map from traded picks.
+   * Mirrors iOS liveTeamsBySlotByRound.
+   *
+   * Algorithm:
+   *   1. Build rosterId → userId map from rosters.
+   *   2. For each traded pick: the pick was originally owned by previous_owner_id (rosterId),
+   *      and now belongs to owner_id (rosterId). Find the slot from base map for
+   *      previous_owner_id's userId, then override that slot's name with owner_id's team name.
+   *
+   * Key: Sleeper traded_picks records use roster_id, not draft_slot.
+   * We bridge through the draft_order: userId → slot → find which roster maps to that userId.
+   */
+  private buildSlotByRound(
+    tradedPicks: TradedPick[],
+    totalRounds: number,
+    rosters: Roster[],
+    users: User[],
+  ): Map<number, Map<number, string>> {
+    const slotByRound = new Map<number, Map<number, string>>()
+
+    // Build rosterId → userId lookup
+    const rosterToUser = new Map<number, string>()
+    rosters.forEach(r => {
+      if (r.owner_id) rosterToUser.set(r.roster_id, r.owner_id)
+    })
+
+    // Build userId → slot lookup (inverse of draft_order)
+    const draft = this.draft
+    const userToSlot = new Map<string, number>()
+    if (draft?.draft_order) {
+      Object.entries(draft.draft_order).forEach(([userId, slot]) => {
+        userToSlot.set(userId, slot)
+      })
+    }
+
+    tradedPicks.forEach(tp => {
+      const round = tp.round
+
+      // Get the original owner's userId and find their draft slot
+      const originalUserId = rosterToUser.get(tp.previous_owner_id)
+      if (!originalUserId) return
+
+      const slot = userToSlot.get(originalUserId)
+      if (slot == null) return
+
+      // Get the current owner's team name
+      const currentUserId = rosterToUser.get(tp.owner_id)
+      if (!currentUserId) return
+
+      const currentUser = users.find(u => u.user_id === currentUserId)
+      const currentName =
+        (currentUser?.metadata?.team_name as string) ||
+        currentUser?.display_name ||
+        currentUser?.username ||
+        `Roster ${tp.owner_id}`
+
+      // Set the override for this round/slot
+      if (!slotByRound.has(round)) {
+        slotByRound.set(round, new Map())
+      }
+      slotByRound.get(round)!.set(slot, currentName)
+    })
+
+    return slotByRound
+  }
+
+  /** Resolve owner name for a given round/slot, applying traded_picks override. */
+  ownerNameForCell(round: number, slot: number): string {
+    return this.slotByRound.get(round)?.get(slot) ?? this.baseSlotToName.get(slot) ?? `Slot ${slot}`
+  }
+
+  private startCountdown(draft: DraftModel): void {
+    interval(1000).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.countdown = this.computeCountdown(draft)
+    })
+    this.countdown = this.computeCountdown(draft)
+  }
+
+  private computeCountdown(draft: DraftModel): string {
+    if (draft.status === 'complete') return 'Draft complete'
+    if (draft.status === 'pre_draft') {
+      if (!draft.start_time) return 'Draft not yet scheduled'
+      const msLeft = draft.start_time - Date.now()
+      if (msLeft <= 0) return 'Starting soon...'
+      return this.formatMs(msLeft)
+    }
+    if (draft.status === 'drafting') {
+      return 'Draft in progress'
+    }
+    return ''
+  }
+
+  private formatMs(ms: number): string {
+    const totalSecs = Math.floor(ms / 1000)
+    const days = Math.floor(totalSecs / 86400)
+    const hours = Math.floor((totalSecs % 86400) / 3600)
+    const mins = Math.floor((totalSecs % 3600) / 60)
+    const secs = totalSecs % 60
+
+    if (days > 0) return `${days}d ${hours}h ${mins}m`
+    if (hours > 0) return `${hours}h ${mins}m ${secs}s`
+    return `${mins}m ${secs}s`
+  }
+
+  private startPolling(draft: DraftModel): void {
+    if (draft.status === 'complete') return
+
+    const pollInterval = draft.status === 'drafting' ? 5000 : 30000
+
+    interval(pollInterval).pipe(
+      switchMap(() => this.draftService.getDraftPicks(draft)),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
+      next: (picks) => {
+        draft.addPicks(picks)
+        this.buildRounds(draft, picks)
+        // Stop polling once complete
+        if (draft.status === 'complete') {
+          this.countdown = 'Draft complete'
+        }
+      },
+    })
+
+    // Build initial rounds immediately from cached picks
+    this.draftService.getDraftPicks(draft).pipe(take(1)).subscribe(picks => {
+      this.buildRounds(draft, picks)
+    })
+  }
+
+  private buildRounds(draft: DraftModel, picks: DraftPick[]): void {
+    const pickMap = new Map<string, DraftPick>()
+    picks.forEach(p => pickMap.set(`${p.round}.${p.draft_slot}`, p))
+
+    const totalRounds = draft.settings?.rounds ?? 15
+    this.rounds = []
+
+    for (let r = 1; r <= totalRounds; r++) {
+      const cells: LiveCell[] = []
+      for (let s = 1; s <= this.teamCount; s++) {
+        const pick = pickMap.get(`${r}.${s}`) ?? null
+        const ownerName = this.ownerNameForCell(r, s)
+        const isMine = pick ? pick.picked_by === this.mySleeperUserId : false
+        cells.push({ round: r, slot: s, ownerName, pick, isMine })
+      }
+      this.rounds.push({ round: r, cells })
+    }
+  }
+
+  // =========================================
+  // View controls
+  // =========================================
+
+  setViewMode(mode: ViewMode): void {
+    this.viewMode = mode
+  }
+
+  setPickFilter(filter: PickFilter): void {
+    this.pickFilter = filter
+  }
+
+  get filteredRounds(): LiveRound[] {
+    if (this.pickFilter === 'all') return this.rounds
+    // My Picks: only show rows that have at least one of my picks in rounds list
+    return this.rounds.map(r => ({
+      ...r,
+      cells: r.cells.filter(c => c.isMine),
+    })).filter(r => r.cells.length > 0)
+  }
+
+  isCellDimmed(cell: LiveCell): boolean {
+    return this.pickFilter === 'mine' && !cell.isMine
+  }
+
+  get draftStatusLabel(): string {
+    if (!this.draft) return ''
+    const labels: Record<string, string> = {
+      pre_draft: 'Pre-Draft',
+      drafting: 'Live',
+      complete: 'Complete',
+      paused: 'Paused',
+    }
+    return labels[this.draft.status] ?? this.draft.status
+  }
+}

--- a/src/app/pages/draft-history/mocks/draft-mocks.component.html
+++ b/src/app/pages/draft-history/mocks/draft-mocks.component.html
@@ -1,0 +1,33 @@
+<div class="draft-mocks">
+  <app-loader [loading]="loading"></app-loader>
+
+  <div *ngIf="!loading">
+    <!-- Non-admin empty state -->
+    <div class="empty-state" *ngIf="!isAdmin && cards.length === 0">
+      <p>Mock draft reports are visible to admins only.</p>
+    </div>
+
+    <!-- No reports (admin but none generated) -->
+    <div class="empty-state" *ngIf="isAdmin && cards.length === 0">
+      <p>No mock draft reports yet.</p>
+      <p class="hint">Trigger a mock draft analysis from the Admin panel to generate one.</p>
+    </div>
+
+    <!-- Report cards -->
+    <div class="mocks-list" *ngIf="cards.length > 0">
+      <div class="mock-card" *ngFor="let card of cards">
+        <button class="card-header" (click)="toggleCard(card)">
+          <div class="card-meta">
+            <span class="card-title">{{ card.displayTitle }}</span>
+            <span class="card-date">{{ card.report.createdAt | date:'MMM d, y' }}</span>
+          </div>
+          <span class="expand-icon" [class.open]="card.expanded">&#9660;</span>
+        </button>
+
+        <div class="card-body" *ngIf="card.expanded">
+          <app-styled-markdown [markdown]="card.report.bodyMarkdown"></app-styled-markdown>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/draft-history/mocks/draft-mocks.component.scss
+++ b/src/app/pages/draft-history/mocks/draft-mocks.component.scss
@@ -1,0 +1,107 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+
+.draft-mocks {
+  min-height: 200px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: $spacing-2xl;
+  background: $card-gradient;
+  border-radius: $radius-lg;
+  border: 1px solid rgba($surface-light, 0.2);
+
+  p {
+    font-size: $text-lg;
+    color: $text-secondary;
+    margin: 0;
+  }
+
+  .hint {
+    font-size: $text-sm;
+    color: $text-muted;
+    margin-top: $spacing-sm;
+  }
+}
+
+.mocks-list {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-md;
+}
+
+.mock-card {
+  background: $card-gradient;
+  border: 1px solid rgba($surface-light, 0.3);
+  border-radius: $radius-lg;
+  overflow: hidden;
+  transition: border-color $transition-base;
+
+  &:hover {
+    border-color: rgba($champion-gold, 0.3);
+  }
+}
+
+.card-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: $spacing-md $spacing-lg;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: $text-primary;
+  transition: background $transition-fast;
+
+  &:hover {
+    background: rgba($surface-light, 0.15);
+  }
+}
+
+.card-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: $text-base;
+  color: $champion-gold;
+}
+
+.card-date {
+  font-size: $text-xs;
+  color: $text-muted;
+  font-family: $font-mono;
+}
+
+.expand-icon {
+  font-size: $text-sm;
+  color: $text-secondary;
+  transition: transform $transition-base;
+
+  &.open {
+    transform: rotate(180deg);
+  }
+}
+
+.card-body {
+  padding: $spacing-lg;
+  padding-top: 0;
+  border-top: 1px solid rgba($surface-light, 0.2);
+  padding-top: $spacing-lg;
+}
+
+@media (max-width: 768px) {
+  .card-header {
+    padding: $spacing-md;
+  }
+
+  .card-body {
+    padding: $spacing-md;
+  }
+}

--- a/src/app/pages/draft-history/mocks/draft-mocks.component.ts
+++ b/src/app/pages/draft-history/mocks/draft-mocks.component.ts
@@ -1,0 +1,66 @@
+import { Component, OnInit } from '@angular/core'
+import { take } from 'rxjs'
+import { AiReviewService } from 'src/app/services/ai-review.service'
+import { SupabaseService } from 'src/app/services/supabase.service'
+import { AiReport, aiReportFormattedPeriod } from 'src/app/models/ai-report.model'
+import { StyledMarkdownComponent } from 'src/app/components/styled-markdown/styled-markdown.component'
+import { LoaderComponent } from '../../../components/loader/loader.component'
+import { NgIf, NgFor, DatePipe } from '@angular/common'
+
+interface MockReportCard {
+  report: AiReport
+  expanded: boolean
+  displayTitle: string
+}
+
+/**
+ * Mocks sub-tab — read-only list of stored mock-draft AI reports.
+ * Admin-gated: non-admins see an empty state (defense-in-depth, server also strips).
+ * No MockDraftEngine port — read-only. (Engine port deferred to s9b.)
+ */
+@Component({
+  selector: 'app-draft-mocks',
+  templateUrl: './draft-mocks.component.html',
+  styleUrls: ['./draft-mocks.component.scss'],
+  standalone: true,
+  imports: [LoaderComponent, NgIf, NgFor, DatePipe, StyledMarkdownComponent],
+})
+export class DraftMocksComponent implements OnInit {
+  loading = true
+  cards: MockReportCard[] = []
+  isAdmin = false
+
+  constructor(
+    private aiReviewService: AiReviewService,
+    private supabase: SupabaseService,
+  ) {}
+
+  ngOnInit(): void {
+    this.isAdmin = this.supabase.isAdmin
+    this.loadMocks()
+  }
+
+  loadMocks(): void {
+    this.loading = true
+    this.aiReviewService
+      .list({ type: 'mock', forUser: { isAdmin: this.isAdmin } })
+      .pipe(take(1))
+      .subscribe({
+        next: (result) => {
+          this.cards = result.rows.map(r => ({
+            report: r,
+            expanded: false,
+            displayTitle: aiReportFormattedPeriod(r.period) || r.period,
+          }))
+          this.loading = false
+        },
+        error: () => {
+          this.loading = false
+        },
+      })
+  }
+
+  toggleCard(card: MockReportCard): void {
+    card.expanded = !card.expanded
+  }
+}

--- a/src/app/pages/draft-history/picks/draft-picks.component.html
+++ b/src/app/pages/draft-history/picks/draft-picks.component.html
@@ -1,0 +1,65 @@
+<div class="draft-picks">
+  <app-loader [loading]="loading"></app-loader>
+
+  <div *ngIf="!loading">
+    <!-- Empty State -->
+    <div class="empty-state" *ngIf="draftRounds.length === 0">
+      <p>No draft picks found for {{ year }}.</p>
+      <p class="hint">Draft picks will appear here once the draft is complete.</p>
+    </div>
+
+    <!-- Draft Rounds -->
+    <div class="draft-rounds" *ngIf="draftRounds.length > 0">
+      <div class="round-section" *ngFor="let round of draftRounds">
+        <h2 class="round-title">Round {{ round.round }}</h2>
+
+        <div class="picks-grid">
+          <div
+            class="pick-card"
+            *ngFor="let pick of round.picks"
+            [ngStyle]="getTeamStyle(pick.player_team)"
+          >
+            <!-- Pick Number -->
+            <div class="pick-number">{{ pick.pick_no }}</div>
+
+            <!-- Player Info -->
+            <div class="player-section">
+              <img
+                [src]="'https://sleepercdn.com/content/nfl/players/thumb/' + pick.player_id + '.jpg'"
+                (error)="$any($event.target).src = 'assets/img/nfl.png'"
+                alt="{{ pick.player_name }}"
+                class="player-pic"
+              />
+              <div class="player-details">
+                <h3 class="player-name">{{ pick.player_name }}</h3>
+                <div class="player-meta">
+                  <span class="position-badge" [ngClass]="getPositionClass(pick.player_position)">
+                    {{ pick.player_position }}
+                  </span>
+                  <span class="team-abbr">{{ pick.player_team || 'FA' }}</span>
+                </div>
+              </div>
+              <img
+                *ngIf="pick.player_team"
+                [src]="'https://sleepercdn.com/images/team_logos/nfl/' + pick.player_team.toLowerCase() + '.png'"
+                alt="{{ pick.player_team }}"
+                class="team-logo"
+              />
+            </div>
+
+            <!-- Picked By -->
+            <div class="picked-by">
+              <span class="picked-label">Picked by:</span>
+              <span class="team-name">{{ pick.picked_by_team_name || pick.picked_by_username }}</span>
+            </div>
+
+            <!-- Keeper Badge -->
+            <div class="keeper-badge" *ngIf="pick.is_keeper">
+              KEEPER
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/draft-history/picks/draft-picks.component.scss
+++ b/src/app/pages/draft-history/picks/draft-picks.component.scss
@@ -1,0 +1,196 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+
+// Empty State
+.empty-state {
+  text-align: center;
+  padding: $spacing-2xl;
+  background: $card-gradient;
+  border-radius: $radius-lg;
+  border: 1px solid rgba($surface-light, 0.2);
+
+  p {
+    font-size: $text-lg;
+    color: $text-secondary;
+    margin: 0;
+  }
+
+  .hint {
+    font-size: $text-sm;
+    color: $text-muted;
+    margin-top: $spacing-sm;
+  }
+}
+
+// Draft Rounds
+.draft-rounds {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-xl;
+}
+
+.round-section {
+  background: $card-gradient;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba($surface-light, 0.2);
+  border-radius: $radius-lg;
+  padding: $spacing-lg;
+}
+
+.round-title {
+  font-family: $font-display;
+  font-size: 1.5rem;
+  letter-spacing: 0.05em;
+  color: $champion-gold;
+  margin-bottom: $spacing-lg;
+  padding-bottom: $spacing-sm;
+  border-bottom: 2px solid rgba($champion-gold, 0.3);
+}
+
+// Picks Grid
+.picks-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: $spacing-md;
+}
+
+.pick-card {
+  position: relative;
+  background: rgba($dark-navy, 0.6);
+  border: 1px solid rgba($surface-light, 0.3);
+  border-radius: $radius-lg;
+  padding: $spacing-md;
+  transition: all $transition-base;
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: $shadow-lg;
+    border-color: rgba($champion-gold, 0.4);
+  }
+}
+
+.pick-number {
+  position: absolute;
+  top: $spacing-sm;
+  left: $spacing-sm;
+  width: 32px;
+  height: 32px;
+  background: $gold-accent;
+  color: $deep-navy;
+  border-radius: $radius-full;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: $text-sm;
+  font-family: $font-mono;
+}
+
+.player-section {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  margin-left: 40px;
+  margin-bottom: $spacing-sm;
+}
+
+.player-pic {
+  width: 50px;
+  height: 50px;
+  border-radius: $radius-full;
+  object-fit: cover;
+  border: 2px solid $surface-light;
+}
+
+.player-details {
+  flex: 1;
+  min-width: 0;
+
+  .player-name {
+    font-size: $text-base;
+    font-weight: 600;
+    margin: 0;
+    color: $text-primary;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .player-meta {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+    margin-top: 4px;
+  }
+}
+
+.position-badge {
+  font-size: $text-xs;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: $radius-sm;
+  text-transform: uppercase;
+
+  &.pos-qb { background: #e74c3c; color: white; }
+  &.pos-rb { background: #27ae60; color: white; }
+  &.pos-wr { background: #3498db; color: white; }
+  &.pos-te { background: #f39c12; color: white; }
+  &.pos-k { background: #9b59b6; color: white; }
+  &.pos-def { background: #34495e; color: white; }
+}
+
+.team-abbr {
+  font-size: $text-xs;
+  color: $text-secondary;
+  font-family: $font-mono;
+}
+
+.team-logo {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.picked-by {
+  display: flex;
+  align-items: center;
+  gap: $spacing-xs;
+  padding-top: $spacing-sm;
+  border-top: 1px solid rgba($surface-light, 0.2);
+  margin-top: $spacing-sm;
+
+  .picked-label {
+    font-size: $text-xs;
+    color: $text-muted;
+  }
+
+  .team-name {
+    font-size: $text-sm;
+    color: $text-primary;
+    font-weight: 500;
+  }
+}
+
+.keeper-badge {
+  position: absolute;
+  top: $spacing-sm;
+  right: $spacing-sm;
+  background: $steel-blue;
+  color: white;
+  font-size: $text-xs;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: $radius-sm;
+  text-transform: uppercase;
+}
+
+@media (max-width: 768px) {
+  .picks-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .round-section {
+    padding: $spacing-md;
+  }
+}

--- a/src/app/pages/draft-history/picks/draft-picks.component.ts
+++ b/src/app/pages/draft-history/picks/draft-picks.component.ts
@@ -1,0 +1,104 @@
+import { Component, OnInit } from '@angular/core'
+import { ActivatedRoute, Router } from '@angular/router'
+import { switchMap, take } from 'rxjs'
+import { LeagueService } from 'src/app/services/league.service'
+import { LeagueHistoryService, DraftHistoryRecord } from 'src/app/services/league-history.service'
+import { ToastService } from 'src/app/services/toast.service'
+import { TEAM_COLORS } from 'src/app/constants/team-colors'
+import { LoaderComponent } from '../../../components/loader/loader.component'
+import { NgIf, NgFor, NgStyle, NgClass } from '@angular/common'
+
+interface DraftRound {
+  round: number
+  picks: DraftHistoryRecord[]
+}
+
+/**
+ * Picks sub-tab — past season draft board rendered by round.
+ * Lifts the existing grid rendering from the pre-s4 DraftHistoryComponent.
+ */
+@Component({
+  selector: 'app-draft-picks',
+  templateUrl: './draft-picks.component.html',
+  styleUrls: ['./draft-picks.component.scss'],
+  standalone: true,
+  imports: [LoaderComponent, NgIf, NgFor, NgStyle, NgClass],
+})
+export class DraftPicksComponent implements OnInit {
+  loading = false
+  draftRounds: DraftRound[] = []
+  year = ''
+
+  constructor(
+    private leagueService: LeagueService,
+    private historyService: LeagueHistoryService,
+    private toastService: ToastService,
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    const league = this.leagueService.getMyLeague()
+    if (!league) {
+      this.router.navigate(['/home'])
+      return
+    }
+
+    // Year comes from parent route (/draft-history/:year/picks)
+    this.year = this.route.parent?.snapshot.paramMap.get('year') ?? ''
+    const leagueId = league.getId()
+
+    this.loading = true
+    this.leagueService.getLeagueChain(leagueId).pipe(
+      switchMap(chain => this.historyService.getDraftHistoryFromChain(chain)),
+      take(1),
+    ).subscribe({
+      next: (drafts) => {
+        const seasonDrafts = drafts.filter(d => d.season === this.year)
+        this.groupByRound(seasonDrafts)
+        this.loading = false
+      },
+      error: () => {
+        this.toastService.showNegativeToast('Error loading draft picks')
+        this.loading = false
+      },
+    })
+  }
+
+  groupByRound(drafts: DraftHistoryRecord[]): void {
+    const roundMap = new Map<number, DraftHistoryRecord[]>()
+    drafts.forEach(pick => {
+      if (!roundMap.has(pick.round)) {
+        roundMap.set(pick.round, [])
+      }
+      roundMap.get(pick.round)!.push(pick)
+    })
+
+    this.draftRounds = Array.from(roundMap.entries())
+      .map(([round, picks]) => ({
+        round,
+        picks: picks.sort((a, b) => a.pick_no - b.pick_no),
+      }))
+      .sort((a, b) => a.round - b.round)
+  }
+
+  getTeamStyle(team: string | undefined) {
+    if (!team) return { backgroundColor: '#2a2a2a' }
+    const colors = TEAM_COLORS[team.toLowerCase()]
+    return colors
+      ? { background: `linear-gradient(135deg, ${colors.primary}40, ${colors.secondary}40)` }
+      : { backgroundColor: '#2a2a2a' }
+  }
+
+  getPositionClass(position: string): string {
+    const posMap: Record<string, string> = {
+      QB: 'pos-qb',
+      RB: 'pos-rb',
+      WR: 'pos-wr',
+      TE: 'pos-te',
+      K: 'pos-k',
+      DEF: 'pos-def',
+    }
+    return posMap[position] || ''
+  }
+}

--- a/src/app/pages/draft-history/recap/draft-recap.component.html
+++ b/src/app/pages/draft-history/recap/draft-recap.component.html
@@ -1,0 +1,31 @@
+<div class="draft-recap">
+  <app-loader [loading]="loading"></app-loader>
+
+  <div *ngIf="!loading">
+    <!-- Has report -->
+    <div class="recap-report" *ngIf="report">
+      <div class="report-header">
+        <h2 class="report-title">{{ year }} Draft Recap</h2>
+        <span class="report-meta">{{ report.createdAt | date:'MMM d, y' }}</span>
+      </div>
+
+      <div class="report-body">
+        <app-styled-markdown [markdown]="report.bodyMarkdown"></app-styled-markdown>
+      </div>
+
+      <!-- TODO(grades): DraftGradesCard would mount here.
+           Deferred — no web FantasyCalc values service exists.
+           Follow-up: s4b-draft-grades. -->
+      <div class="grades-deferred-notice">
+        <span class="notice-icon">ℹ️</span>
+        Draft grades coming in a future update.
+      </div>
+    </div>
+
+    <!-- No report -->
+    <div class="empty-state" *ngIf="!report">
+      <p>No recap report available for {{ year }}.</p>
+      <p class="hint">Post-draft analysis will appear here after it's generated.</p>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/draft-history/recap/draft-recap.component.scss
+++ b/src/app/pages/draft-history/recap/draft-recap.component.scss
@@ -1,0 +1,85 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+
+.draft-recap {
+  min-height: 200px;
+}
+
+.recap-report {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-lg;
+}
+
+.report-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: $spacing-md;
+  flex-wrap: wrap;
+
+  .report-title {
+    font-family: $font-display;
+    font-size: 1.75rem;
+    letter-spacing: 0.04em;
+    color: $champion-gold;
+    margin: 0;
+  }
+
+  .report-meta {
+    font-size: $text-sm;
+    color: $text-muted;
+    font-family: $font-mono;
+  }
+}
+
+.report-body {
+  background: $card-gradient;
+  border: 1px solid rgba($surface-light, 0.3);
+  border-radius: $radius-lg;
+  padding: $spacing-xl;
+}
+
+.grades-deferred-notice {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  background: rgba($surface-light, 0.2);
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  padding: $spacing-md;
+  font-size: $text-sm;
+  color: $text-muted;
+  font-style: italic;
+
+  .notice-icon {
+    font-size: $text-base;
+    flex-shrink: 0;
+  }
+}
+
+.empty-state {
+  text-align: center;
+  padding: $spacing-2xl;
+  background: $card-gradient;
+  border-radius: $radius-lg;
+  border: 1px solid rgba($surface-light, 0.2);
+
+  p {
+    font-size: $text-lg;
+    color: $text-secondary;
+    margin: 0;
+  }
+
+  .hint {
+    font-size: $text-sm;
+    color: $text-muted;
+    margin-top: $spacing-sm;
+  }
+}
+
+@media (max-width: 768px) {
+  .report-body {
+    padding: $spacing-md;
+  }
+}

--- a/src/app/pages/draft-history/recap/draft-recap.component.ts
+++ b/src/app/pages/draft-history/recap/draft-recap.component.ts
@@ -1,0 +1,66 @@
+import { Component, OnInit } from '@angular/core'
+import { ActivatedRoute, Router } from '@angular/router'
+import { take } from 'rxjs'
+import { AiReviewService } from 'src/app/services/ai-review.service'
+import { AiReport } from 'src/app/models/ai-report.model'
+import { StyledMarkdownComponent } from 'src/app/components/styled-markdown/styled-markdown.component'
+import { LoaderComponent } from '../../../components/loader/loader.component'
+import { NgIf, DatePipe } from '@angular/common'
+
+/**
+ * Recap sub-tab — renders the stored post-draft AI report for the selected year.
+ *
+ * Year matching: postDraft reports use `period` = season year (e.g. "2025").
+ * This is confirmed by `aiReportFormattedPeriod` returning the period unchanged
+ * when no 'W' char is found — postDraft periods are year-only strings.
+ * Fallback: also matches on createdAt calendar year if period match fails.
+ *
+ * TODO(grades): DraftGradesCard port deferred — no web FantasyCalc values service exists.
+ * Track in follow-up s4b-draft-grades.
+ */
+@Component({
+  selector: 'app-draft-recap',
+  templateUrl: './draft-recap.component.html',
+  styleUrls: ['./draft-recap.component.scss'],
+  standalone: true,
+  imports: [LoaderComponent, NgIf, DatePipe, StyledMarkdownComponent],
+})
+export class DraftRecapComponent implements OnInit {
+  loading = true
+  report: AiReport | null = null
+  year = ''
+
+  constructor(
+    private aiReviewService: AiReviewService,
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.year = this.route.parent?.snapshot.paramMap.get('year') ?? ''
+    this.loadRecap()
+  }
+
+  loadRecap(): void {
+    this.loading = true
+    this.aiReviewService.list({ type: 'postDraft', limit: 20 }).pipe(take(1)).subscribe({
+      next: (result) => {
+        // Match on period (year string like "2025") — primary strategy
+        let match = result.rows.find(r => r.period === this.year)
+
+        // Fallback: match on createdAt calendar year
+        if (!match && this.year) {
+          match = result.rows.find(r =>
+            new Date(r.createdAt).getFullYear().toString() === this.year,
+          )
+        }
+
+        this.report = match ?? null
+        this.loading = false
+      },
+      error: () => {
+        this.loading = false
+      },
+    })
+  }
+}


### PR DESCRIPTION
## Summary

Restructures `/draft-history` from a flat page into an iOS-matching per-year shell with nested sub-tab routes (`/draft-history/:year/{live|picks|recap|mocks}`).

- **Shell** (`DraftHistoryComponent`): year chip switcher, sub-tab bar filtered by season type, `<router-outlet>` for sub-tab content. Current season → Live/Mocks/Recap; past seasons → Picks/Recap.
- **Live** (`DraftLiveComponent`): iOS `LiveDraftView` port. Board grid + rounds list view, All/My Picks toggle, live countdown via `interval(1000)`, `traded_picks` per-round ownership override (`liveTeamsBySlotByRound`), 5s/30s polling via `interval + switchMap + takeUntilDestroyed`.
- **Picks** (`DraftPicksComponent`): existing draft board rendering lifted from pre-s4 shell. Past-season default.
- **Recap** (`DraftRecapComponent`): fetches `postDraft` AI report via `AiReviewService`, matches by `period` (year string, e.g. `"2025"`), renders via `StyledMarkdownComponent`. `createdAt` year fallback included.
- **Mocks** (`DraftMocksComponent`): read-only mock-draft report list, expandable cards, admin-gated empty state.

## Decisions / Deviations

- **Draft grades deferred**: no web FantasyCalc values service exists. `TODO(grades)` note added in `DraftRecapComponent` where `DraftGradesCard` would mount. Follow-up: `s4b-draft-grades`.
- **`period` field confirmed**: `postDraft` periods are plain year strings. `aiReportFormattedPeriod` returns `period` unchanged when no `'W'` present — `report.period === year` match is correct.
- **Routing**: two flat routes (`draft-history` + `draft-history/:year`) rather than nested parent/child-same-component to avoid Angular double-instantiation.
- **`sidebar.entries.ts`**: already pointed at `/draft-history` with `// s4 restructures` comment — no change needed.

## Test plan

- [ ] `/draft-history` navigates to current season live sub-tab
- [ ] Year chips switch years and reset to correct default sub-tab
- [ ] Current season shows Live / Mocks / Recap tabs; past season shows Picks / Recap
- [ ] Live board grid and rounds list both render
- [ ] All/My Picks toggle works in both view modes
- [ ] Traded pick ownership override shows correct team per round
- [ ] Recap renders stored postDraft markdown report
- [ ] Mocks visible to admin; empty state for non-admin
- [ ] Deep link `/draft-history/2024/picks` survives browser refresh
- [ ] `/selected-team` and other guest routes unregressed
- [ ] `npm run build` clean (pre-existing bundle budget warning only)

Closes #92