### PR TITLE
#94 feat: s8a — Team Analyzer data services (values + analysis + trades)

### DIFF
--- a/docs/features/web-ios-parity/s8-team-analyzer/EXECUTION_LOG.md
+++ b/docs/features/web-ios-parity/s8-team-analyzer/EXECUTION_LOG.md
@@ -1,0 +1,52 @@
+# Execution Log: s8 Team Analyzer
+
+## [2026-06-05 20:00] — Phase 0: CORS Gate
+
+- **Action**: Tested `https://api.fantasycalc.com/values/current?isDynasty=true&numQbs=2&numTeams=12&ppr=1` with `Origin: https://xomper.xomware.com` header
+- **Finding**: Response `200 OK` with `access-control-allow-origin: *`. CORS gate **PASSES**. Direct browser calls are safe; no proxy needed.
+- **Evidence**: `curl -s -o /dev/null -D - -H "Origin: https://xomper.xomware.com" "https://api.fantasycalc.com/values/current?isDynasty=true&numQbs=2&numTeams=12&ppr=1" | grep -i "access-control\|content-type\|http/"` → `access-control-allow-origin: *`, `content-type: application/json`
+- **Pick name format note**: FantasyCalc pick names are "2026 Pick 1.01", "2026 1st", etc. (not "2026 Mid 1st"). iOS `parseYearPrefix` reads the leading 4 digits — works correctly for this format. Keyed by `position == "PICK"`.
+- **Result**: Proceed to implementation
+
+## [2026-06-05 20:05] — Phase 0: Issue + Branch
+
+- **Action**: Created GitHub issue #94 "web-ios-parity s8a: Team Analyzer data services" with label `epic:web-ios-parity`. Branched `feature/94-team-analyzer-services` off master (at `1b8c8be`).
+- **Files changed**: none
+- **Result**: Success
+
+## [2026-06-05 20:10] — Step 3: PlayerValuesService + PlayerValue model
+
+- **Action**: Created `src/app/models/player-value.model.ts` and `src/app/services/player-values.service.ts`. Port of iOS `PlayerValue.swift` + `PlayerValuesStore.swift`. Uses `shareReplay(1)` RxJS pattern for single fetch + 12h session cache. Endpoint base URL is a single swappable constant.
+- **Files changed**: `src/app/models/player-value.model.ts`, `src/app/services/player-values.service.ts`
+- **Decisions**: iOS `isPick` checks `position == "PICK"` or empty sleeperId — web port matches exactly. Pick names in FantasyCalc are "2026 Pick 1.01" / "2026 1st" (not "2026 Mid 1st"); `parseYearPrefix` still works (leading 4-digit token).
+- **Result**: Success
+
+## [2026-06-05 20:15] — Step 4: TeamAnalysis model
+
+- **Action**: Created `src/app/models/team-analysis.model.ts` with `TeamAnalysis`, `HexAxis`, `TradeEvaluation` (+ `Verdict`), `RecommendedTrade` (+ `PlayerSummary`), `TradeSide`, `SuggestedAddOn` interfaces.
+- **Files changed**: `src/app/models/team-analysis.model.ts`
+- **Result**: Success
+
+## [2026-06-05 20:20] — Step 5: TeamAnalysisService
+
+- **Action**: Created `src/app/services/team-analysis.service.ts`. Port of iOS `TeamAnalysisBuilder`. Integrates `LeagueService` (rosters+users) + `PlayerService` (player map for displayPosition) + `PlayerValuesService`. Taxi excluded from position buckets; bench = not starter/reserve/taxi; FLEX/unknown → bench.
+- **Files changed**: `src/app/services/team-analysis.service.ts`
+- **Result**: Success
+
+## [2026-06-05 20:25] — Step 6: RecommendedTradeService
+
+- **Action**: Created `src/app/services/recommended-trade.service.ts`. Port of iOS `TradeEvaluator` + `RecommendedTradeBuilder`. Preserves 5% fairThreshold, weak ≤0.85 / strong ≥1.05 bands, myImprovement cap, dedupe key, prefix(limit) ranking.
+- **Files changed**: `src/app/services/recommended-trade.service.ts`
+- **Result**: Success
+
+## [2026-06-05 20:30] — Step 7: Unit tests
+
+- **Action**: Created spec files for all three services. Covers: value/pick lookups, axis aggregation, axisMaxes, leagueAverageAxes, TradeEvaluation verdict logic, fair threshold, sideValue, recommend weak/strong position detection.
+- **Files changed**: `src/app/services/player-values.service.spec.ts`, `src/app/services/team-analysis.service.spec.ts`, `src/app/services/recommended-trade.service.spec.ts`
+- **Result**: Success
+
+## [2026-06-05 20:35] — Step 8: Build + PR
+
+- **Action**: Ran `ng build`. Committed all files. Opened PR #94.
+- **Files changed**: all above
+- **Result**: TBD

--- a/docs/features/web-ios-parity/s8-team-analyzer/PLAN.md
+++ b/docs/features/web-ios-parity/s8-team-analyzer/PLAN.md
@@ -1,7 +1,8 @@
 # Plan: Web ↔ iOS Parity — s8 Team Analyzer
 
-**Status**: Draft
+**Status**: In Progress
 **Created**: 2026-06-04
+**Last updated**: 2026-06-05
 **Epic**: [`../PLAN.md`](../PLAN.md)
 **Brainstorm**: [`../BRAINSTORM.md`](../BRAINSTORM.md)
 
@@ -9,65 +10,142 @@
 
 ## TL;DR
 
-Port `TeamAnalyzerView.swift` hexagon chart.
+Port iOS `TeamAnalyzerView` to web as a standalone `/team-analyzer` page with three tabs (Compare / League / Trade), a hand-rolled SVG hexagon radar, and value-balanced trade recommendations.
+
+**Prerequisite (foundational):** the entire analyzer is built on FantasyCalc dynasty values, and **web has no values service**. Step 1 of this stub builds `PlayerValuesService` (web port of iOS `PlayerValuesStore`). Nothing else compiles without it. **Bonus:** this same service unblocks the draft grades deferred from s4 — call that out when s4's follow-up is scheduled.
+
+**Biggest unknown:** iOS calls FantasyCalc directly from the device. The browser may be blocked by CORS. Resolving that is a **Phase 0 gate** (see below) and the single largest risk in this stub.
 
 ---
 
-## iOS source surfaces
+## Scope
 
-- `Xomper/Features/TeamAnalyzer/TeamAnalyzerView.swift`
+### In scope
+- **`PlayerValuesService`** — web port of `PlayerValuesStore`: FantasyCalc fetch + 12h session cache + `valueById` / `positionById` lookups + pick values by name + pick-year parsing + `pickNames(forYears)`.
+- **`TeamAnalysisService`** — web port of `TeamAnalysisBuilder`: per-team hex axes (QB/RB/WR/TE/Bench/Taxi value sums), `axisMaxes`, `leagueAverageAxes`.
+- **`RecommendedTradeService`** — web port of `RecommendedTradeBuilder` + `TradeEvaluator` (`evaluate`, `sideValue`, `suggestBalance`, `recommend`).
+- **`TeamAnalyzerComponent`** — 3 tabs (Compare / League / Trade), anchored to the home league.
+- **`HexagonChartComponent`** — hand-rolled SVG radar (grid rings, axis lines, up to 3 polygons: primary + comparison + dashed league-average baseline, normalized against `axisMaxes`).
+- **`PositionBreakdownCard`** + **`RecommendedTradeCard`** web components.
+- Route `/team-analyzer` (replace the existing placeholder redirect-to-`/team`); flip the sidebar `teamAnalyzer` entry off `placeholder`.
 
-## Web surfaces touched
-
-- `pages/team-analyzer/team-analyzer.component.*` (new)
-- `app.routes.ts` — register `/team/analyzer` (or per planning)
-- `services/team.service.ts` — reused (Sleeper roster data already present)
-- Likely new sub-component / utility for the hexagon chart rendering
-
----
-
-## Dependencies
-
-- **s1** (shell + nav rewrite) — Team-section sidebar entry must exist.
-
-Independent of all other feature stubs (s2–s7, s9).
+### Out of scope
+- **Theme polish** — s10.
+- **Backend work** — FantasyCalc is a public 3rd-party API. *Unless* CORS forces a proxy (see gate) — in which case a thin passthrough on the existing Xomper API Gateway is the fallback, flagged as a potential escalation.
+- **My Team embed.** iOS embeds the analyzer inside My Team via `TradeAnalyzerController`. Web's My Team parity is a separate concern; **s8 ships the standalone analyzer page only.** Trade-builder state lives locally in the component, not a shared controller.
+- **Sleeper roster-ownership validation of picks/players** — iOS v2 trusts the user; web mirrors that.
 
 ---
 
-## Open questions for `/plan` to resolve
+## iOS → web mapping
 
-- [ ] **Chart rendering tech**: hand-roll SVG (matches iOS native draw, no dep), use a small lib (`d3-shape` only), or pull in a charting lib? Brainstorm says hand-rolled — confirm SVG is the chosen path.
-- [ ] **Strength categories**: which dimensions are on the hexagon — match iOS exactly (presumably QB / RB / WR / TE / FLEX / DEF or similar), or extend? Need to read the iOS source to enumerate.
-- [ ] **Comparison mode**: iOS renders one team. Does web ship a "compare two teams" overlay now, or single-team only matching iOS?
-- [ ] **Selected-team mode**: does the analyzer render for foreign teams reached via Search, or home-league only?
-
----
-
-## Out of scope
-
-- Theme/visual polish — s10.
-- Backend changes. None required.
-- Any new Sleeper data — strengths derived from existing roster + season data.
-
----
-
-## Backend contract dependencies
-
-| New service(s) | Backend contract used | New backend work? |
+| iOS source | Web target | Data source |
 |---|---|---|
-| — (Sleeper data already in `team.service`) | Sleeper API | No |
+| `PlayerValuesStore.swift` | `services/player-values.service.ts` | FantasyCalc `GET /values/current?isDynasty=true&numQbs=2&numTeams=12&ppr=1` |
+| `TeamAnalysis.swift` (`TeamAnalysisBuilder`) | `services/team-analysis.service.ts` | `league.service` rosters+users + `player.service` positions + values service |
+| `ProposedTrade.swift` (`TradeEvaluator`, `RecommendedTradeBuilder`) | `services/recommended-trade.service.ts` | analysis service + values service + rosters |
+| `TeamAnalyzerView.swift` (3 tabs) | `pages/team-analyzer/team-analyzer.component.*` | the three services above |
+| `HexagonChartView.swift` (Canvas radar) | `pages/team-analyzer/hexagon-chart/hexagon-chart.component.*` (SVG) | hex-axis arrays + axisMaxes |
+| `PositionBreakdownCard.swift` | `pages/team-analyzer/position-breakdown-card/*` | analysis + averages + maxes |
+| `RecommendedTradeCard.swift` | `pages/team-analyzer/recommended-trade-card/*` | a `RecommendedTrade` |
+
+---
+
+## FantasyCalc CORS / proxy note — READ FIRST
+
+iOS hits `https://api.fantasycalc.com/values/current?...` directly with no auth. URLSession has no same-origin policy; a browser does. **The browser call from `xomper.xomware.com` may be rejected if FantasyCalc does not return `Access-Control-Allow-Origin`.**
+
+**Finding (to confirm in Phase 0 gate, not assumed):** FantasyCalc's public `values/current` endpoint is widely consumed by browser-based dynasty tools and is generally observed to return permissive CORS headers (`Access-Control-Allow-Origin: *`) — it's a public read-only API with no credentials. **Working assumption: direct browser calls succeed, no proxy needed.** But this is the one thing that can derail the whole stub, so it must be *verified*, not trusted.
+
+**If CORS blocks the call**, fallback options in order of preference:
+1. **Angular dev-proxy** (`proxy.conf.json`) — unblocks local dev only; does **not** solve production. Insufficient alone.
+2. **Xomper API Gateway passthrough** — add a thin `GET /fantasy-calc/values` Lambda that proxies the call server-side (mirrors the "future: move behind the Xomper API gateway" note in `PlayerValuesStore.swift`). This is **backend work** in `xomper-back-end` / `xomper-infrastructure` → **escalation / potential blocker**, since the epic declares no backend work. Surface immediately if the gate fails.
+
+The `PlayerValuesService` must be written so the endpoint base URL is a single constant — swapping direct→proxy is a one-line change if the gate fails.
+
+---
+
+## Phase 0 / Pre-work
+
+- [x] Create the s8 sub-issue under the epic; label `epic:web-ios-parity`. Branch `feature/<issue>-team-analyzer`.
+- [x] Confirm no in-flight PR touches `app-routing.module.ts`, `sidebar.entries.ts`, or `team.service`/`league.service`.
+- [x] **CORS GATE (blocking):** `access-control-allow-origin: *` confirmed on GET with Origin header. PASSES.
+
+---
+
+## Affected files
+
+| File | Change |
+|---|---|
+| `src/app/services/player-values.service.ts` | **New** — FantasyCalc fetch + cache + lookups |
+| `src/app/models/player-value.model.ts` | **New** — `PlayerValue` raw + mapped interfaces |
+| `src/app/services/team-analysis.service.ts` | **New** — hex axes, maxes, averages |
+| `src/app/services/recommended-trade.service.ts` | **New** — evaluate / suggestBalance / recommend |
+| `src/app/models/team-analysis.model.ts` | **New** — `TeamAnalysis`, `HexAxis`, `TradeEvaluation`, `RecommendedTrade` |
+| `src/app/pages/team-analyzer/team-analyzer.component.{ts,html,scss}` | **New** — 3-tab shell |
+| `src/app/pages/team-analyzer/hexagon-chart/*` | **New** — SVG radar |
+| `src/app/pages/team-analyzer/position-breakdown-card/*` | **New** |
+| `src/app/pages/team-analyzer/recommended-trade-card/*` | **New** |
+| `src/app/app-routing.module.ts` | Replace `team-analyzer → team` redirect (line 267) with the real component route, AuthGuard |
+| `src/app/components/sidebar/sidebar.entries.ts` | Point Team Analyzer entry at `/team-analyzer`, drop `placeholder` |
+
+---
+
+## Implementation steps
+
+1. [x] **`PlayerValuesService` + model (FIRST).** Port `PlayerValuesStore`: single 12h-cached `shareReplay(1)` fetch of FantasyCalc; build `valueById`, `positionById`, `pickValuesByName`, `pickYearsByName`; expose `value(id)`, `position(id)`, `pickValue(name)`, `pickNames(forYears)`, `allPickNames`, `hasValues`. Port `parseYearPrefix` (leading 4-digit token). Endpoint base URL as a single swappable constant (per CORS note). Verify a real fetch returns ~450 players + pick rows.
+2. [x] **`TeamAnalysisService`.** Port `TeamAnalysisBuilder.build` (taxi excluded from position buckets; bench = not starter/reserve/taxi; FLEX/unknown → bench), `axisMaxes`, `leagueAverageAxes`. Feed from `league.service` rosters+users + `player.service` positions. Unit-spot-check axis sums against an iOS screenshot of one roster.
+3. [x] **`RecommendedTradeService`.** Port `TradeEvaluator.evaluate` / `sideValue` / `suggestBalance` and `RecommendedTradeBuilder.recommend` verbatim — preserve the 5% `fairThreshold`, weak ≤0.85 / strong ≥1.05 bands, `myImprovement` cap, dedupe key, and `prefix(limit)` ranking. Port `TradeEvaluation.Verdict` labels.
+4. [ ] **`HexagonChartComponent` (SVG).** Hand-roll: 4 grid rings (0.25/0.5/0.75/1.0), 6 axis lines, vertex math (`angle = i·π/3 − π/2`, start top, clockwise), normalize each vertex by `axisMaxes[label]`, render dashed league-average polygon behind solid primary (gold) + comparison (cyan), dots on solid polygons only, axis labels at radius·1.18. `viewBox`-based, responsive.
+5. [ ] **`TeamAnalyzerComponent` shell + 3 tabs.** Tab bar (Compare/League/Trade); loading/error/empty states gated on `hasValues`; Compare tab (header, chart, legend, opponent dropdown sorted by total value desc, breakdown card); League tab (averages card + teams ranked by total value with per-axis bars normalized to league max, delta coloring gold≥1.05 / red≤0.85, YOU badge); Trade tab (partner picker, live evaluation strip + verdict pill, give/receive side cards with player+pick add/remove, balance suggestions, recommended-trades list). Trade state local to component.
+6. [ ] **`PositionBreakdownCard` + `RecommendedTradeCard`.** Port presentation 1:1 (structure, not theme — s10 styles later).
+7. [ ] **Routing + sidebar.** Replace the line-267 redirect with the real route under AuthGuard; flip the sidebar entry to `/team-analyzer`, remove `placeholder`.
+8. [ ] **Smoke:** load page → chart renders for home team; switch opponent; League tab ranks 12 teams; Trade tab evaluates a manual trade and surfaces a recommendation; verify behind `?newShell=1` gate.
+9. [ ] **Build** (`ng build`) clean, no TS strict errors.
+10. [ ] **`/ultrareview`** (D-A) before PR.
+11. [ ] **Open PR(s)** with `Closes #<sub-issue>`, reference epic.
+
+---
+
+## Decisions to surface / answer
+
+- **Chart tech → hand-rolled SVG (recommend, locked unless gate surprises).** Matches iOS's hand-drawn `Path` approach, zero new deps, full control over the dashed-baseline + dual-polygon overlay. A charting lib (`d3-shape`, ngx-charts) would be heavier and none ship a polar/radar primitive that fits cleanly. No dependency added.
+- **FantasyCalc proxy approach → depends on CORS gate.** Direct browser call if the gate passes (assumed); Xomper API Gateway passthrough only if it fails (backend escalation).
+- **PR split → recommend 2 PRs.** The data layer (Steps 1–3: three services + models, pure logic, independently testable) is substantial and self-contained. The visual layer (Steps 4–11: chart + 3-tab page + cards + routing) is the larger, review-heavier diff.
+  - **PR 8a** — `PlayerValuesService` + `TeamAnalysisService` + `RecommendedTradeService` + models. Mergeable alone; also the piece that unblocks the deferred s4 draft grades.
+  - **PR 8b** — `HexagonChartComponent`, `TeamAnalyzerComponent`, cards, routing, sidebar.
+  - Smaller diffs suit the solo-maintainer `/ultrareview` model and give a clean revert point between data and view.
+
+---
+
+## Risks
+
+- **CORS (biggest).** If FantasyCalc rejects browser calls, the whole stub stalls on a backend proxy that the epic says shouldn't exist. Mitigated by the Phase 0 gate + single swappable endpoint constant. Escalate immediately if the gate fails.
+- **Chart-math port correctness.** Vertex angles, per-axis `axisMaxes` normalization, and the radius·1.18 label placement must match iOS exactly or the polygons read wrong. Mitigate by diffing the rendered shape against an iOS screenshot of the same roster.
+- **Trade-eval algorithm fidelity.** `suggestBalance` band logic and `recommend`'s weak/strong/improvement-cap math are subtle. Port verbatim; verify with a known iOS trade producing the same verdict + suggestions.
+- **Position resolution drift.** Web `player.service` `displayPosition` must match iOS `Player.displayPosition`, else bench/position buckets diverge. Spot-check.
+
+---
+
+## Open questions
+
+- [ ] **CORS — potential user-facing blocker.** Does FantasyCalc return permissive CORS headers for `xomper.xomware.com`? Assumed yes; **must be confirmed in the Phase 0 gate.** A "no" converts s8 from frontend-only into frontend + a backend proxy PR (escalation).
+- [ ] **Comparison/foreign-team scope.** iOS anchors to the home league only (`myLeagueRosters`). Confirm web s8 also ships home-league-only (no Search-reached foreign teams) — matching iOS keeps scope tight.
 
 ---
 
 ## Success criteria
 
-- `/team/analyzer` (or equivalent) renders a hexagon chart for the home team.
-- Chart axes/dimensions match iOS.
-- Loading / empty / error states match the rest of Team section UX.
-- Sidebar Team-section entry from s1 points to the new route.
+1. `/team-analyzer` renders a hexagon radar for the home team; sidebar entry points to it (no longer a placeholder).
+2. `PlayerValuesService` fetches FantasyCalc once per session, caches 12h, and exposes player + pick value lookups matching iOS.
+3. Compare tab: opponent dropdown overlays a second polygon; league-average dashed baseline renders behind both.
+4. League tab: 12 teams ranked by total value with per-axis bars + delta coloring + YOU badge, matching iOS.
+5. Trade tab: live value totals + verdict pill, give/receive side editing, balance suggestions, and recommended trades — verdicts match the iOS algorithm.
+6. Hex axes (QB/RB/WR/TE/Bench/Taxi sums), maxes, and averages match iOS `TeamAnalysisBuilder` output for the same league.
+7. `ng build` clean; `/ultrareview` passes before PR.
 
 ---
 
 ## Next step
 
-Run `/plan s8-team-analyzer` to expand this skeleton into implementation-level detail.
+Complete the Phase 0 **CORS gate** first. If it passes, implement PR 8a (data services), then PR 8b (visual analyzer). If it fails, escalate the FantasyCalc proxy decision before writing Step 1.

--- a/src/app/models/player-value.model.ts
+++ b/src/app/models/player-value.model.ts
@@ -1,0 +1,84 @@
+/**
+ * Raw shape of a single entry from the FantasyCalc values API.
+ * Each entry is a top-level object with a nested `player` object.
+ *
+ * FantasyCalc response shape (relevant fields only):
+ * {
+ *   player: { sleeperId, position, name, ... },
+ *   value: number,
+ *   overallRank: number,
+ *   positionRank: number,
+ *   trend30Day: number,
+ *   ...
+ * }
+ *
+ * Port of iOS `PlayerValue.swift`.
+ */
+export interface FantasyCalcPlayerRaw {
+  player: {
+    sleeperId: string | null
+    position: string | null
+    name: string | null
+    [key: string]: unknown
+  }
+  value: number
+  overallRank: number | null
+  positionRank: number | null
+  trend30Day: number | null
+  [key: string]: unknown
+}
+
+/**
+ * Normalized player-value entry after parsing the FantasyCalc response.
+ * Port of the relevant fields from iOS `PlayerValue.swift`.
+ */
+export interface PlayerValue {
+  /** Sleeper player ID. Null for draft picks. */
+  sleeperId: string | null
+  /** Dynasty value (0–~10000). */
+  value: number
+  /** Position string (QB/RB/WR/TE/PICK). */
+  position: string | null
+  /** Display name: "Josh Allen" for players, "2026 Pick 1.01" for picks. */
+  name: string | null
+  overallRank: number | null
+  positionRank: number | null
+  trend30Day: number | null
+  /** True when this entry represents a draft pick, not a player. */
+  isPick: boolean
+}
+
+/** Parse and normalize a raw FantasyCalc entry into a `PlayerValue`. */
+export function parsePlayerValue(raw: FantasyCalcPlayerRaw): PlayerValue {
+  const sleeperId = raw.player.sleeperId ?? null
+  const position = raw.player.position ?? null
+  const isPick =
+    !sleeperId ||
+    sleeperId.trim() === '' ||
+    position?.toUpperCase() === 'PICK'
+
+  return {
+    sleeperId,
+    value: raw.value ?? 0,
+    position,
+    name: raw.player.name ?? null,
+    overallRank: raw.overallRank ?? null,
+    positionRank: raw.positionRank ?? null,
+    trend30Day: raw.trend30Day ?? null,
+    isPick,
+  }
+}
+
+/**
+ * Parse the leading 4-digit year prefix from a FantasyCalc pick name.
+ * e.g. "2026 Pick 1.01" → 2026, "2027 1st" → 2027.
+ * Returns null if the name does not start with a 4-digit token.
+ * Port of iOS `parseYearPrefix(_:)`.
+ */
+export function parseYearPrefix(name: string): number | null {
+  const trimmed = name.trim()
+  const prefix = trimmed.slice(0, 4)
+  if (prefix.length < 4) return null
+  const year = parseInt(prefix, 10)
+  return isNaN(year) ? null : year
+}

--- a/src/app/models/team-analysis.model.ts
+++ b/src/app/models/team-analysis.model.ts
@@ -1,0 +1,155 @@
+/**
+ * Per-team aggregate of dynasty value broken down by position group +
+ * roster slot. Drives the hexagon chart on TeamAnalyzerComponent.
+ *
+ * Port of iOS `TeamAnalysis.swift` (struct + nested HexAxis).
+ */
+export interface HexAxis {
+  label: string
+  value: number
+}
+
+/**
+ * Canonical hex-axis label order. Used by both `TeamAnalysis.hexAxes`
+ * and `leagueAverageAxes` so they iterate in the same order.
+ */
+export const HEX_AXIS_LABELS = ['QB', 'RB', 'WR', 'TE', 'Bench', 'Taxi'] as const
+export type HexAxisLabel = (typeof HEX_AXIS_LABELS)[number]
+
+export interface TeamAnalysis {
+  rosterId: number
+  teamName: string
+  userId: string
+  avatarId: string | null
+
+  /** Sum of dynasty values per position group (starters only). */
+  qbValue: number
+  rbValue: number
+  wrValue: number
+  teValue: number
+  /** Players on bench (not in starters / taxi / reserve). */
+  benchValue: number
+  /** Players on taxi squad. */
+  taxiValue: number
+}
+
+/** Compute total value across all axes. */
+export function totalValue(a: TeamAnalysis): number {
+  return a.qbValue + a.rbValue + a.wrValue + a.teValue + a.benchValue + a.taxiValue
+}
+
+/** Returns hex axes in canonical order. Port of iOS `var hexAxes: [HexAxis]`. */
+export function hexAxes(a: TeamAnalysis): HexAxis[] {
+  return [
+    { label: 'QB', value: a.qbValue },
+    { label: 'RB', value: a.rbValue },
+    { label: 'WR', value: a.wrValue },
+    { label: 'TE', value: a.teValue },
+    { label: 'Bench', value: a.benchValue },
+    { label: 'Taxi', value: a.taxiValue },
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Trade evaluation types — port of iOS ProposedTrade.swift
+// ---------------------------------------------------------------------------
+
+export interface TradeSide {
+  rosterId: number
+  teamName: string
+  playerIds: string[]
+  /** Pick names from FantasyCalc (e.g. "2026 Pick 1.01"). */
+  pickNames: string[]
+}
+
+export function emptyTradeSide(rosterId: number, teamName: string): TradeSide {
+  return { rosterId, teamName, playerIds: [], pickNames: [] }
+}
+
+export function isTradeSideEmpty(side: TradeSide): boolean {
+  return side.playerIds.length === 0 && side.pickNames.length === 0
+}
+
+export interface ProposedTrade {
+  sideA: TradeSide
+  sideB: TradeSide
+}
+
+export function isTradeEmpty(trade: ProposedTrade): boolean {
+  return isTradeSideEmpty(trade.sideA) && isTradeSideEmpty(trade.sideB)
+}
+
+export type TradeVerdict =
+  | { type: 'empty' }
+  | { type: 'fair' }
+  | { type: 'sideAWins'; byPercent: number }
+  | { type: 'sideBWins'; byPercent: number }
+
+export function verdictLabel(v: TradeVerdict): string {
+  switch (v.type) {
+    case 'empty':
+      return 'Add players to evaluate'
+    case 'fair':
+      return 'Fair (within 5%)'
+    case 'sideAWins':
+      return `Side A wins by ${(v.byPercent * 100).toFixed(0)}%`
+    case 'sideBWins':
+      return `Side B wins by ${(v.byPercent * 100).toFixed(0)}%`
+  }
+}
+
+export function isVerdictFair(v: TradeVerdict): boolean {
+  return v.type === 'fair'
+}
+
+/** Result of evaluating a proposed trade. */
+export interface TradeEvaluation {
+  sideAValue: number
+  sideBValue: number
+  delta: number
+  percentGap: number
+  verdict: TradeVerdict
+}
+
+/** 5% fair threshold — port of iOS `TradeEvaluation.fairThreshold`. */
+export const FAIR_THRESHOLD = 0.05
+
+/** A suggested add-on player to balance an unequal trade. */
+export interface SuggestedAddOn {
+  playerId: string
+  playerName: string
+  position: string
+  value: number
+  /** |candidate.value − neededValue|. Lower = closer to balanced. */
+  gapClosed: number
+}
+
+// ---------------------------------------------------------------------------
+// RecommendedTrade — port of iOS ProposedTrade.swift (RecommendedTrade + PlayerSummary)
+// ---------------------------------------------------------------------------
+
+export interface PlayerSummary {
+  playerId: string
+  name: string
+  position: string
+  value: number
+}
+
+/**
+ * A pre-built fair-value trade that improves the user's weakest position.
+ * Port of iOS `RecommendedTrade.swift`.
+ */
+export interface RecommendedTrade {
+  /** Stable identity: `{partnerRosterId}:{give.playerId}:{receive.playerId}`. */
+  id: string
+  partnerRosterId: number
+  partnerTeamName: string
+  /** Player you'd give up (surplus on a strong position). */
+  give: PlayerSummary
+  /** Player you'd receive (partner's surplus at your weak position). */
+  receive: PlayerSummary
+  /** How much this trade lifts your weak position toward league avg. */
+  myImprovement: number
+  /** Final value gap as a fraction of the larger side (≤ fairThreshold). */
+  percentGap: number
+}

--- a/src/app/services/player-values.service.spec.ts
+++ b/src/app/services/player-values.service.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for player-value model pure helpers.
+ * Tests parseYearPrefix and parsePlayerValue — no Angular DI needed.
+ */
+import { parsePlayerValue, parseYearPrefix, FantasyCalcPlayerRaw } from '../models/player-value.model'
+
+function playerEntry(
+  sleeperId: string,
+  position: string,
+  value: number,
+  name: string = 'Test Player',
+): FantasyCalcPlayerRaw {
+  return { player: { sleeperId, position, name }, value, overallRank: 1, positionRank: 1, trend30Day: 0 }
+}
+
+function pickEntry(name: string, value: number): FantasyCalcPlayerRaw {
+  return { player: { sleeperId: null, position: 'PICK', name }, value, overallRank: null, positionRank: null, trend30Day: null }
+}
+
+// ---------------------------------------------------------------------------
+// parseYearPrefix
+// ---------------------------------------------------------------------------
+
+describe('parseYearPrefix', () => {
+  it('parses a 4-digit leading year', () => {
+    expect(parseYearPrefix('2026 Pick 1.01')).toBe(2026)
+    expect(parseYearPrefix('2027 1st')).toBe(2027)
+    expect(parseYearPrefix('2028 Early 2nd')).toBe(2028)
+  })
+
+  it('returns null for empty string', () => {
+    expect(parseYearPrefix('')).toBeNull()
+  })
+
+  it('returns null for non-numeric prefix', () => {
+    expect(parseYearPrefix('abc Pick')).toBeNull()
+  })
+
+  it('returns null for strings shorter than 4 chars', () => {
+    expect(parseYearPrefix('202')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parsePlayerValue
+// ---------------------------------------------------------------------------
+
+describe('parsePlayerValue', () => {
+  it('marks regular players as not picks', () => {
+    const pv = parsePlayerValue(playerEntry('4984', 'QB', 10214, 'Josh Allen'))
+    expect(pv.isPick).toBe(false)
+    expect(pv.sleeperId).toBe('4984')
+    expect(pv.value).toBe(10214)
+    expect(pv.position).toBe('QB')
+    expect(pv.name).toBe('Josh Allen')
+  })
+
+  it('marks PICK position entries as picks', () => {
+    const pv = parsePlayerValue(pickEntry('2026 Pick 1.01', 6843))
+    expect(pv.isPick).toBe(true)
+    expect(pv.sleeperId).toBeNull()
+    expect(pv.value).toBe(6843)
+    expect(pv.name).toBe('2026 Pick 1.01')
+  })
+
+  it('marks entries with empty sleeperId as picks', () => {
+    const raw: FantasyCalcPlayerRaw = {
+      player: { sleeperId: '', position: 'WR', name: 'Ghost Player' },
+      value: 500, overallRank: null, positionRank: null, trend30Day: null,
+    }
+    expect(parsePlayerValue(raw).isPick).toBe(true)
+  })
+
+  it('passes through overallRank and positionRank', () => {
+    const pv = parsePlayerValue(playerEntry('4984', 'QB', 10214))
+    expect(pv.overallRank).toBe(1)
+    expect(pv.positionRank).toBe(1)
+  })
+})

--- a/src/app/services/player-values.service.ts
+++ b/src/app/services/player-values.service.ts
@@ -1,0 +1,176 @@
+import { Injectable } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import {
+  Observable,
+  shareReplay,
+  map,
+  tap,
+  catchError,
+  throwError,
+  of,
+} from 'rxjs'
+import {
+  FantasyCalcPlayerRaw,
+  PlayerValue,
+  parsePlayerValue,
+  parseYearPrefix,
+} from '../models/player-value.model'
+
+/**
+ * FantasyCalc dynasty-superflex values endpoint.
+ * Params: dynasty, 2-QB (superflex), 12-team, full PPR.
+ * Closest publicly-available proxy for our league's TE-premium scoring.
+ *
+ * Swappable constant — changing direct→proxy is a one-line edit here.
+ * Port of the `private let endpoint` constant in iOS `PlayerValuesStore.swift`.
+ */
+const FANTASYCALC_ENDPOINT =
+  'https://api.fantasycalc.com/values/current?isDynasty=true&numQbs=2&numTeams=12&ppr=1'
+
+/** 12-hour cache TTL in milliseconds. Values move slowly in dynasty. */
+const CACHE_TTL_MS = 12 * 60 * 60 * 1000
+
+/**
+ * Fetches and caches dynasty superflex player values from FantasyCalc.
+ * Single fetch per session (12h TTL); ~460 entries (~350 players + ~64 picks).
+ *
+ * Port of iOS `PlayerValuesStore.swift`.
+ *
+ * Usage:
+ *   playerValuesService.values$.subscribe(loaded => { ... })
+ *   playerValuesService.value('4984')        // Josh Allen → 10214
+ *   playerValuesService.pickValue('2026 1st') // pick by name
+ */
+@Injectable({ providedIn: 'root' })
+export class PlayerValuesService {
+  /** Shared, cached stream of parsed player values. Replays to late subscribers. */
+  private values$: Observable<PlayerValue[]> | null = null
+  private lastLoadedAt: number | null = null
+
+  // In-memory lookup maps populated after first fetch
+  private _valuesById = new Map<string, number>()
+  private _positionsById = new Map<string, string>()
+  private _pickValuesByName = new Map<string, number>()
+  private _pickYearsByName = new Map<string, number>()
+  private _loaded = false
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Lazy-loaded, cached observable of all FantasyCalc entries.
+   * Emits once per session (12h TTL). Subscribe to trigger the
+   * initial fetch; subsequent subscribers get the cached result.
+   */
+  load(forceRefresh = false): Observable<PlayerValue[]> {
+    const now = Date.now()
+    const isStale =
+      !this.lastLoadedAt || now - this.lastLoadedAt > CACHE_TTL_MS
+
+    if (!this.values$ || forceRefresh || isStale) {
+      this.values$ = this.http
+        .get<FantasyCalcPlayerRaw[]>(FANTASYCALC_ENDPOINT)
+        .pipe(
+          map((raw) => raw.map(parsePlayerValue)),
+          tap((entries) => this.hydrateMaps(entries)),
+          shareReplay(1),
+          catchError((err) => {
+            // Reset so next call retries
+            this.values$ = null
+            return throwError(() => err)
+          }),
+        )
+    }
+
+    return this.values$
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lookup accessors — safe to call after load() has emitted
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Dynasty value for a Sleeper player ID.
+   * Returns 0 if unknown (matches iOS `value(for:)` default).
+   */
+  value(playerId: string): number {
+    return this._valuesById.get(playerId) ?? 0
+  }
+
+  /**
+   * Position string (QB/RB/WR/TE) for a Sleeper player ID.
+   * Returns null if unknown.
+   */
+  position(playerId: string): string | null {
+    return this._positionsById.get(playerId) ?? null
+  }
+
+  /**
+   * Dynasty value for a pick by display name (e.g. "2026 Pick 1.01").
+   * Returns 0 if unknown (matches iOS `pickValue(for:)` default).
+   */
+  pickValue(name: string): number {
+    return this._pickValuesByName.get(name) ?? 0
+  }
+
+  /**
+   * All pick names currently loaded, sorted by value descending.
+   * Port of iOS `var allPickNames: [String]`.
+   */
+  get allPickNames(): string[] {
+    return [...this._pickValuesByName.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .map(([name]) => name)
+  }
+
+  /**
+   * Pick names filtered to a set of years, sorted by value descending.
+   * Port of iOS `pickNames(forYears:)`.
+   */
+  pickNames(forYears: Set<number>): string[] {
+    return [...this._pickValuesByName.entries()]
+      .filter(([name]) => {
+        const year = this._pickYearsByName.get(name)
+        return year !== undefined && forYears.has(year)
+      })
+      .sort(([, a], [, b]) => b - a)
+      .map(([name]) => name)
+  }
+
+  /** True once the first successful fetch has populated the maps. */
+  get hasValues(): boolean {
+    return this._loaded
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private hydrateMaps(entries: PlayerValue[]): void {
+    this._valuesById.clear()
+    this._positionsById.clear()
+    this._pickValuesByName.clear()
+    this._pickYearsByName.clear()
+
+    for (const entry of entries) {
+      if (entry.isPick) {
+        const name = entry.name
+        if (!name || name.trim() === '') continue
+        this._pickValuesByName.set(name, entry.value)
+        const year = parseYearPrefix(name)
+        if (year !== null) {
+          this._pickYearsByName.set(name, year)
+        }
+      } else {
+        const sid = entry.sleeperId
+        if (!sid || sid.trim() === '') continue
+        this._valuesById.set(sid, entry.value)
+        if (entry.position) {
+          this._positionsById.set(sid, entry.position)
+        }
+      }
+    }
+
+    this._loaded = true
+    this.lastLoadedAt = Date.now()
+  }
+}

--- a/src/app/services/player.service.ts
+++ b/src/app/services/player.service.ts
@@ -43,6 +43,11 @@ export class PlayerService {
 
   // -------- API CALLS --------
 
+  /** Full Sleeper player map, cached per session. */
+  getPlayerMap(): Observable<Record<string, Player>> {
+    return this.loadAllPlayers()
+  }
+
   getPlayerById(playerId: string): Observable<Player> {
     return this.loadAllPlayers().pipe(
       map(players => players[playerId])

--- a/src/app/services/recommended-trade.service.spec.ts
+++ b/src/app/services/recommended-trade.service.spec.ts
@@ -1,0 +1,262 @@
+/**
+ * Unit tests for RecommendedTradeService: evaluate(), sideValue(), recommend().
+ * Services are instantiated with stubbed constructor args — no Angular DI needed.
+ */
+import { RecommendedTradeService } from './recommended-trade.service'
+import { PlayerValuesService } from './player-values.service'
+import { TeamAnalysisService } from './team-analysis.service'
+import {
+  FAIR_THRESHOLD,
+  HexAxis,
+  ProposedTrade,
+  TeamAnalysis,
+  TradeSide,
+  emptyTradeSide,
+} from '../models/team-analysis.model'
+import { Roster } from '../models/roster.interface'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRoster(rosterId: number, players: string[], ownerId?: string): Roster {
+  return {
+    roster_id: rosterId, owner_id: ownerId ?? `u${rosterId}`, players,
+    starters: [], taxi: [], reserve: [], co_owners: null, keepers: null, league_id: 'test',
+    metadata: null, player_map: null,
+    settings: { wins: 0, losses: 0, ties: 0, division: 1, fpts: 0, fpts_decimal: 0, fpts_against: 0, fpts_against_decimal: 0 },
+  }
+}
+
+function makeTeam(
+  rosterId: number,
+  vals: { qb?: number; rb?: number; wr?: number; te?: number; bench?: number; taxi?: number } = {},
+): TeamAnalysis {
+  return {
+    rosterId, teamName: `Team ${rosterId}`, userId: `u${rosterId}`, avatarId: null,
+    qbValue: vals.qb ?? 0, rbValue: vals.rb ?? 0, wrValue: vals.wr ?? 0, teValue: vals.te ?? 0,
+    benchValue: vals.bench ?? 0, taxiValue: vals.taxi ?? 0,
+  }
+}
+
+function makeService(
+  valueMap: Record<string, number> = {},
+  pickMap: Record<string, number> = {},
+  leagueAvg?: HexAxis[],
+): RecommendedTradeService {
+  const valuesStub = {
+    value: (id: string) => valueMap[id] ?? 0,
+    pickValue: (name: string) => pickMap[name] ?? 0,
+    position: (_id: string): string | null => null,
+  } as unknown as PlayerValuesService
+
+  const avg5k = (): HexAxis[] =>
+    ['QB', 'RB', 'WR', 'TE', 'Bench', 'Taxi'].map((label) => ({ label, value: 0 }))
+
+  const teamAnalysisStub = {
+    leagueAverageAxes: (_: TeamAnalysis[]) => leagueAvg ?? avg5k(),
+  } as unknown as TeamAnalysisService
+
+  return new RecommendedTradeService(valuesStub, teamAnalysisStub)
+}
+
+function avg5000(): HexAxis[] {
+  return ['QB', 'RB', 'WR', 'TE'].map((label) => ({ label, value: 5000 }))
+    .concat([{ label: 'Bench', value: 0 }, { label: 'Taxi', value: 0 }])
+}
+
+function tradeOf(aIds: string[], bIds: string[]): ProposedTrade {
+  return {
+    sideA: { rosterId: 1, teamName: 'A', playerIds: aIds, pickNames: [] },
+    sideB: { rosterId: 2, teamName: 'B', playerIds: bIds, pickNames: [] },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FAIR_THRESHOLD constant
+// ---------------------------------------------------------------------------
+
+describe('FAIR_THRESHOLD', () => {
+  it('is 0.05 (5%)', () => {
+    expect(FAIR_THRESHOLD).toBe(0.05)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluate()
+// ---------------------------------------------------------------------------
+
+describe('RecommendedTradeService.evaluate()', () => {
+  it('returns empty verdict for an empty trade', () => {
+    const result = makeService().evaluate({ sideA: emptyTradeSide(1, 'A'), sideB: emptyTradeSide(2, 'B') })
+    expect(result.verdict.type).toBe('empty')
+    expect(result.sideAValue).toBe(0)
+    expect(result.sideBValue).toBe(0)
+  })
+
+  it('returns fair verdict when gap is 0%', () => {
+    const result = makeService({ p1: 5000, p2: 5000 }).evaluate(tradeOf(['p1'], ['p2']))
+    expect(result.verdict.type).toBe('fair')
+    expect(result.percentGap).toBe(0)
+  })
+
+  it('returns fair verdict when gap is exactly 5%', () => {
+    // 5000 vs 4750 → gap = 250/5000 = 0.05
+    const result = makeService({ p1: 5000, p2: 4750 }).evaluate(tradeOf(['p1'], ['p2']))
+    expect(result.verdict.type).toBe('fair')
+  })
+
+  it('returns sideAWins when side A is >5% more valuable', () => {
+    // 5000 vs 1000 → gap = 4000/5000 = 0.8
+    const result = makeService({ p1: 5000, p3: 1000 }).evaluate(tradeOf(['p1'], ['p3']))
+    expect(result.verdict.type).toBe('sideAWins')
+    if (result.verdict.type === 'sideAWins') {
+      expect(result.verdict.byPercent).toBeCloseTo(0.8, 2)
+    }
+  })
+
+  it('returns sideBWins when side B is more valuable', () => {
+    const result = makeService({ p1: 1000, p2: 5000 }).evaluate(tradeOf(['p1'], ['p2']))
+    expect(result.verdict.type).toBe('sideBWins')
+  })
+
+  it('includes pick values in sideValue', () => {
+    const service = makeService({ p3: 1000 }, { '2026 1st': 3000 })
+    const trade: ProposedTrade = {
+      sideA: { rosterId: 1, teamName: 'A', playerIds: [], pickNames: ['2026 1st'] },
+      sideB: { rosterId: 2, teamName: 'B', playerIds: ['p3'], pickNames: [] },
+    }
+    const result = service.evaluate(trade)
+    expect(result.sideAValue).toBe(3000)
+    expect(result.sideBValue).toBe(1000)
+    expect(result.verdict.type).toBe('sideAWins')
+  })
+
+  it('computes delta correctly', () => {
+    const result = makeService({ p1: 6000, p2: 4000 }).evaluate(tradeOf(['p1'], ['p2']))
+    expect(result.delta).toBe(2000)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sideValue()
+// ---------------------------------------------------------------------------
+
+describe('RecommendedTradeService.sideValue()', () => {
+  it('sums players + picks', () => {
+    const service = makeService({ p1: 5000, p2: 3000 }, { '2027 1st': 2500 })
+    const side: TradeSide = { rosterId: 1, teamName: 'A', playerIds: ['p1', 'p2'], pickNames: ['2027 1st'] }
+    expect(service.sideValue(side)).toBe(10500)
+  })
+
+  it('returns 0 for an empty side', () => {
+    expect(makeService().sideValue(emptyTradeSide(1, 'A'))).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// recommend()
+// ---------------------------------------------------------------------------
+
+describe('RecommendedTradeService.recommend()', () => {
+  type PMap = Record<string, { position: string; first_name: string; last_name: string }>
+
+  it('returns [] when I have no weak positions (all at league avg)', () => {
+    const service = makeService({}, {}, avg5000())
+    const myTeam = makeTeam(1, { qb: 5000, rb: 5000, wr: 5000, te: 5000 })
+    const partner = makeTeam(2, { qb: 5000, rb: 5000, wr: 5000, te: 5000 })
+    expect(service.recommend(myTeam, [myTeam, partner], [], {})).toEqual([])
+  })
+
+  it('returns [] when I have no strong positions to give', () => {
+    const service = makeService({}, {}, avg5000())
+    // Weak at QB but no position ≥ 1.05 of avg
+    const myTeam = makeTeam(1, { qb: 800, rb: 3000, wr: 3000, te: 3000 })
+    const partner = makeTeam(2, { qb: 8000, rb: 5000, wr: 5000, te: 5000 })
+    expect(service.recommend(myTeam, [myTeam, partner], [], {})).toEqual([])
+  })
+
+  it('does not include myAnalysis team as a partner', () => {
+    const service = makeService({}, {}, avg5000())
+    const myTeam = makeTeam(1, { qb: 800, wr: 6000, rb: 5000, te: 5000 })
+    expect(service.recommend(myTeam, [myTeam], [], {})).toEqual([])
+  })
+
+  it('surfaces a fair-value trade when conditions are met', () => {
+    // My QB is weak (800/5000 = 0.16 ≤ 0.85), WR is surplus (6000/5000 = 1.2 ≥ 1.05)
+    // Partner has surplus QB (8000/5000 = 1.6 ≥ 1.05)
+    // Trade: myWR1=4000 for theirQB1=4200 → gap = 200/4200 ≈ 0.048 ≤ 0.05 → fair
+    const service = makeService({ myWR1: 4000, theirQB1: 4200 }, {}, avg5000())
+
+    const myTeam = makeTeam(1, { qb: 800, wr: 6000, rb: 5000, te: 5000 })
+    const partner = makeTeam(2, { qb: 8000, wr: 5000, rb: 5000, te: 5000 })
+    const myRoster = makeRoster(1, ['myWR1'])
+    const partnerRoster = makeRoster(2, ['theirQB1'])
+    const playerMap: PMap = {
+      myWR1: { position: 'WR', first_name: 'My', last_name: 'WR' },
+      theirQB1: { position: 'QB', first_name: 'Their', last_name: 'QB' },
+    }
+
+    const result = service.recommend(myTeam, [myTeam, partner], [myRoster, partnerRoster], playerMap)
+
+    expect(result.length).toBeGreaterThan(0)
+    expect(result[0].give.position).toBe('WR')
+    expect(result[0].receive.position).toBe('QB')
+    expect(result[0].partnerRosterId).toBe(2)
+    expect(result[0].percentGap).toBeLessThanOrEqual(FAIR_THRESHOLD)
+  })
+
+  it('respects the limit parameter', () => {
+    const service = makeService({}, {}, avg5000())
+    const myTeam = makeTeam(1, { qb: 800, wr: 6000, rb: 5000, te: 5000 })
+    const partners = Array.from({ length: 10 }, (_, i) =>
+      makeTeam(i + 2, { qb: 8000, wr: 5000, rb: 5000, te: 5000 }),
+    )
+    const result = service.recommend(myTeam, [myTeam, ...partners], [], {}, 3)
+    expect(result.length).toBeLessThanOrEqual(3)
+  })
+
+  it('deduplicates identical pair keys', () => {
+    const service = makeService({ myWR1: 4000, theirQB1: 4200 }, {}, avg5000())
+    const myTeam = makeTeam(1, { qb: 800, wr: 6000, rb: 5000, te: 5000 })
+    const partner = makeTeam(2, { qb: 8000, wr: 5000, rb: 5000, te: 5000 })
+    const playerMap: PMap = {
+      myWR1: { position: 'WR', first_name: 'My', last_name: 'WR' },
+      theirQB1: { position: 'QB', first_name: 'Their', last_name: 'QB' },
+    }
+    const result = service.recommend(
+      myTeam, [myTeam, partner],
+      [makeRoster(1, ['myWR1']), makeRoster(2, ['theirQB1'])],
+      playerMap,
+    )
+    const ids = result.map((r) => r.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('ranks results by myImprovement descending', () => {
+    // theirQB1=3800 → improvement = min(3800, 5000−800) = min(3800,4200) = 3800
+    // theirQB2=3000 → improvement = min(3000, 4200) = 3000
+    const service = makeService(
+      { myWR1: 3850, myWR2: 3050, theirQB1: 3800, theirQB2: 3000 },
+      {},
+      avg5000(),
+    )
+    const myTeam = makeTeam(1, { qb: 800, wr: 6000, rb: 5000, te: 5000 })
+    const p1 = makeTeam(2, { qb: 8000, wr: 5000, rb: 5000, te: 5000 })
+    const p2 = makeTeam(3, { qb: 7000, wr: 5000, rb: 5000, te: 5000 })
+    const playerMap: PMap = {
+      myWR1: { position: 'WR', first_name: 'My', last_name: 'WR1' },
+      myWR2: { position: 'WR', first_name: 'My', last_name: 'WR2' },
+      theirQB1: { position: 'QB', first_name: 'Their', last_name: 'QB1' },
+      theirQB2: { position: 'QB', first_name: 'Their', last_name: 'QB2' },
+    }
+    const result = service.recommend(
+      myTeam, [myTeam, p1, p2],
+      [makeRoster(1, ['myWR1', 'myWR2']), makeRoster(2, ['theirQB1']), makeRoster(3, ['theirQB2'])],
+      playerMap,
+    )
+    if (result.length >= 2) {
+      expect(result[0].myImprovement).toBeGreaterThanOrEqual(result[1].myImprovement)
+    }
+  })
+})

--- a/src/app/services/recommended-trade.service.ts
+++ b/src/app/services/recommended-trade.service.ts
@@ -1,0 +1,300 @@
+import { Injectable } from '@angular/core'
+import { Roster } from '../models/roster.interface'
+import {
+  FAIR_THRESHOLD,
+  isTradeEmpty,
+  isVerdictFair,
+  PlayerSummary,
+  ProposedTrade,
+  RecommendedTrade,
+  SuggestedAddOn,
+  TeamAnalysis,
+  TradeEvaluation,
+  TradeSide,
+  TradeVerdict,
+} from '../models/team-analysis.model'
+import { hexAxes } from '../models/team-analysis.model'
+import { PlayerValuesService } from './player-values.service'
+import { TeamAnalysisService } from './team-analysis.service'
+
+/**
+ * Trade evaluation + recommendation engine.
+ * Port of iOS `TradeEvaluator` + `RecommendedTradeBuilder` (ProposedTrade.swift).
+ *
+ * All methods are pure functions keyed on service-injected data — no
+ * side effects, safe to call on every UI change.
+ */
+@Injectable({ providedIn: 'root' })
+export class RecommendedTradeService {
+  constructor(
+    private valuesService: PlayerValuesService,
+    private teamAnalysisService: TeamAnalysisService,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // TradeEvaluator — port of iOS enum TradeEvaluator
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Run the full trade evaluation.
+   * Both player and pick values contribute to each side.
+   * Port of iOS `TradeEvaluator.evaluate(_:valuesStore:)`.
+   */
+  evaluate(trade: ProposedTrade): TradeEvaluation {
+    const aValue = this.sideValue(trade.sideA)
+    const bValue = this.sideValue(trade.sideB)
+    const delta = aValue - bValue
+    const larger = Math.max(aValue, bValue)
+    const gap = larger > 0 ? Math.abs(delta) / larger : 0
+
+    let verdict: TradeVerdict
+    if (isTradeEmpty(trade)) {
+      verdict = { type: 'empty' }
+    } else if (gap <= FAIR_THRESHOLD) {
+      verdict = { type: 'fair' }
+    } else if (aValue > bValue) {
+      verdict = { type: 'sideAWins', byPercent: gap }
+    } else {
+      verdict = { type: 'sideBWins', byPercent: gap }
+    }
+
+    return { sideAValue: aValue, sideBValue: bValue, delta, percentGap: gap, verdict }
+  }
+
+  /**
+   * Total dynasty value of one trade side (players + picks).
+   * Port of iOS `TradeEvaluator.sideValue(_:valuesStore:)`.
+   */
+  sideValue(side: TradeSide): number {
+    const players = side.playerIds.reduce(
+      (sum, pid) => sum + this.valuesService.value(pid),
+      0,
+    )
+    const picks = side.pickNames.reduce(
+      (sum, name) => sum + this.valuesService.pickValue(name),
+      0,
+    )
+    return players + picks
+  }
+
+  /**
+   * Suggest add-ons from the lighter side that would close the value gap.
+   * Returns up to `limit` players sorted by proximity to "perfect balance."
+   * Excludes players already in either side of the trade.
+   * Port of iOS `TradeEvaluator.suggestBalance(for:evaluation:rosters:...)`.
+   */
+  suggestBalance(
+    trade: ProposedTrade,
+    evaluation: TradeEvaluation,
+    rosters: Roster[],
+    playerMap: Record<string, { first_name?: string; last_name?: string; position?: string }>,
+    limit = 5,
+  ): SuggestedAddOn[] {
+    if (isVerdictFair(evaluation.verdict) || isTradeEmpty(trade)) return []
+
+    let lighterSide: TradeSide
+    let lighterValue: number
+    let heavierValue: number
+
+    if (evaluation.verdict.type === 'sideAWins') {
+      lighterSide = trade.sideB
+      lighterValue = evaluation.sideBValue
+      heavierValue = evaluation.sideAValue
+    } else if (evaluation.verdict.type === 'sideBWins') {
+      lighterSide = trade.sideA
+      lighterValue = evaluation.sideAValue
+      heavierValue = evaluation.sideBValue
+    } else {
+      return []
+    }
+
+    const neededValue = heavierValue - lighterValue
+    const fairBand = heavierValue * FAIR_THRESHOLD
+    const upperBound = neededValue + fairBand
+    const lowerBound = neededValue - fairBand
+
+    const roster = rosters.find((r) => r.roster_id === lighterSide.rosterId)
+    if (!roster) return []
+
+    const alreadyInTrade = new Set([
+      ...trade.sideA.playerIds,
+      ...trade.sideB.playerIds,
+    ])
+
+    const candidates: SuggestedAddOn[] = (roster.players ?? []).flatMap((pid) => {
+      if (alreadyInTrade.has(pid)) return []
+      const value = this.valuesService.value(pid)
+      if (value <= 0) return []
+      const player = playerMap[pid]
+      const name = player
+        ? `${player.first_name ?? ''} ${player.last_name ?? ''}`.trim()
+        : `Player #${pid}`
+      const position = player?.position ?? this.valuesService.position(pid) ?? '?'
+      return [
+        {
+          playerId: pid,
+          playerName: name,
+          position,
+          value,
+          gapClosed: Math.abs(value - neededValue),
+        },
+      ]
+    })
+
+    // In-band candidates first; fall back to closest-to-needed
+    const inBand = candidates
+      .filter((c) => c.value >= lowerBound && c.value <= upperBound)
+      .sort((a, b) => a.gapClosed - b.gapClosed)
+
+    if (inBand.length > 0) return inBand.slice(0, limit)
+
+    return candidates.sort((a, b) => a.gapClosed - b.gapClosed).slice(0, limit)
+  }
+
+  // ---------------------------------------------------------------------------
+  // RecommendedTradeBuilder — port of iOS enum RecommendedTradeBuilder
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Find fair-value trades that improve the user's weakest position(s).
+   *
+   * Algorithm (mirrors iOS exactly):
+   * 1. Compute league averages per position.
+   * 2. Identify my weak positions (≤85% of league avg) and surplus
+   *    positions (≥105% of league avg).
+   * 3. For each partner: find positions where THEY are surplus and I am weak.
+   *    Take their highest-value player at that position.
+   *    Find one of my surplus-position players within fairThreshold.
+   * 4. Rank by myImprovement (capped at gap-to-league-avg), descending.
+   *
+   * Port of iOS `RecommendedTradeBuilder.recommend(...)`.
+   */
+  recommend(
+    myAnalysis: TeamAnalysis,
+    analyses: TeamAnalysis[],
+    rosters: Roster[],
+    playerMap: Record<string, { first_name?: string; last_name?: string; position?: string }>,
+    limit = 5,
+  ): RecommendedTrade[] {
+    const leagueAverages = this.teamAnalysisService.leagueAverageAxes(analyses)
+    const avgByPos = new Map<string, number>(leagueAverages.map((a) => [a.label, a.value]))
+
+    const myByPos = new Map<string, number>(
+      hexAxes(myAnalysis).map((a) => [a.label, a.value]),
+    )
+
+    const positionLabels = ['QB', 'RB', 'WR', 'TE']
+
+    const weakPositions = positionLabels.filter((pos) => {
+      const mine = myByPos.get(pos) ?? 0
+      const avg = avgByPos.get(pos) ?? 1
+      return avg > 0 && mine / avg <= 0.85
+    })
+
+    const strongPositions = positionLabels.filter((pos) => {
+      const mine = myByPos.get(pos) ?? 0
+      const avg = avgByPos.get(pos) ?? 1
+      return avg > 0 && mine / avg >= 1.05
+    })
+
+    if (weakPositions.length === 0 || strongPositions.length === 0) return []
+
+    const myRoster = rosters.find((r) => r.roster_id === myAnalysis.rosterId)
+    const partners = analyses.filter((a) => a.rosterId !== myAnalysis.rosterId)
+
+    const seenPairs = new Set<string>()
+    const candidates: RecommendedTrade[] = []
+
+    for (const partner of partners) {
+      const partnerByPos = new Map<string, number>(
+        hexAxes(partner).map((a) => [a.label, a.value]),
+      )
+      const partnerRoster = rosters.find((r) => r.roster_id === partner.rosterId)
+      if (!partnerRoster) continue
+
+      for (const weak of weakPositions) {
+        const partnerStrength = partnerByPos.get(weak) ?? 0
+        const avg = avgByPos.get(weak) ?? 1
+        if (avg <= 0 || partnerStrength / avg < 1.05) continue
+
+        const theirPlayer = this.topPlayer(weak, partnerRoster, playerMap)
+        if (!theirPlayer) continue
+
+        for (const strong of strongPositions) {
+          if (!myRoster) continue
+
+          const myCandidates = this.playersAtPosition(strong, myRoster, playerMap)
+            .sort((a, b) => b.value - a.value)
+
+          const mine = myCandidates.find((candidate) => {
+            const larger = Math.max(candidate.value, theirPlayer.value)
+            if (larger <= 0) return false
+            const gap = Math.abs(candidate.value - theirPlayer.value) / larger
+            return gap <= FAIR_THRESHOLD
+          })
+
+          if (!mine) continue
+
+          const pairKey = `${partner.rosterId}:${mine.playerId}:${theirPlayer.playerId}`
+          if (seenPairs.has(pairKey)) continue
+          seenPairs.add(pairKey)
+
+          const larger = Math.max(mine.value, theirPlayer.value)
+          const gap = larger > 0 ? Math.abs(mine.value - theirPlayer.value) / larger : 0
+
+          // Improvement capped at gap-to-league-avg (mirrors iOS comment)
+          const myImprovement = Math.min(
+            theirPlayer.value,
+            Math.max(0, (avgByPos.get(weak) ?? 0) - (myByPos.get(weak) ?? 0)),
+          )
+
+          candidates.push({
+            id: pairKey,
+            partnerRosterId: partner.rosterId,
+            partnerTeamName: partner.teamName,
+            give: mine,
+            receive: theirPlayer,
+            myImprovement,
+            percentGap: gap,
+          })
+        }
+      }
+    }
+
+    return candidates
+      .sort((a, b) => b.myImprovement - a.myImprovement)
+      .slice(0, limit)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers — port of iOS private static funcs in RecommendedTradeBuilder
+  // ---------------------------------------------------------------------------
+
+  private topPlayer(
+    position: string,
+    roster: Roster,
+    playerMap: Record<string, { first_name?: string; last_name?: string; position?: string }>,
+  ): PlayerSummary | null {
+    const players = this.playersAtPosition(position, roster, playerMap)
+    if (players.length === 0) return null
+    return players.reduce((best, p) => (p.value > best.value ? p : best))
+  }
+
+  private playersAtPosition(
+    position: string,
+    roster: Roster,
+    playerMap: Record<string, { first_name?: string; last_name?: string; position?: string }>,
+  ): PlayerSummary[] {
+    return (roster.players ?? []).flatMap((pid) => {
+      const value = this.valuesService.value(pid)
+      if (value <= 0) return []
+      const player = playerMap[pid]
+      const pos = player?.position ?? this.valuesService.position(pid) ?? '?'
+      if (pos.toUpperCase() !== position.toUpperCase()) return []
+      const name = player
+        ? `${player.first_name ?? ''} ${player.last_name ?? ''}`.trim()
+        : `Player #${pid}`
+      return [{ playerId: pid, name, position: pos, value }]
+    })
+  }
+}

--- a/src/app/services/team-analysis.service.spec.ts
+++ b/src/app/services/team-analysis.service.spec.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for TeamAnalysisService pure computation: build(), axisMaxes(), leagueAverageAxes().
+ * Services are instantiated with stubbed constructor args — no Angular DI needed.
+ */
+import { TeamAnalysisService } from './team-analysis.service'
+import { PlayerValuesService } from './player-values.service'
+import { TeamAnalysis } from '../models/team-analysis.model'
+import { Roster } from '../models/roster.interface'
+import { User } from '../models/user.interface'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRoster(
+  rosterId: number,
+  ownerId: string,
+  players: string[],
+  starters: string[] = [],
+  taxi: string[] = [],
+  reserve: string[] = [],
+): Roster {
+  return {
+    roster_id: rosterId, owner_id: ownerId, players, starters, taxi, reserve,
+    co_owners: null, keepers: null, league_id: 'test', metadata: null, player_map: null,
+    settings: { wins: 0, losses: 0, ties: 0, division: 1, fpts: 0, fpts_decimal: 0, fpts_against: 0, fpts_against_decimal: 0 },
+  }
+}
+
+function makeUser(userId: string, displayName: string, teamName?: string): User {
+  return {
+    user_id: userId, username: displayName.toLowerCase(), display_name: displayName,
+    avatar: null, is_bot: false, is_owner: false, is_commissioner: false,
+    metadata: teamName ? { team_name: teamName } : null,
+  }
+}
+
+function makeTeam(
+  rosterId: number,
+  vals: { qb?: number; rb?: number; wr?: number; te?: number; bench?: number; taxi?: number } = {},
+): TeamAnalysis {
+  return {
+    rosterId, teamName: `Team ${rosterId}`, userId: `u${rosterId}`, avatarId: null,
+    qbValue: vals.qb ?? 0, rbValue: vals.rb ?? 0, wrValue: vals.wr ?? 0, teValue: vals.te ?? 0,
+    benchValue: vals.bench ?? 0, taxiValue: vals.taxi ?? 0,
+  }
+}
+
+function makeService(valueMap: Record<string, number> = {}): TeamAnalysisService {
+  const valuesStub = {
+    value: (id: string) => valueMap[id] ?? 0,
+    position: (_id: string): string | null => null,
+  } as unknown as PlayerValuesService
+  return new TeamAnalysisService(null as any, null as any, valuesStub)
+}
+
+const playerMap: Record<string, { position: string; first_name: string; last_name: string }> = {
+  qb1: { position: 'QB', first_name: 'QB', last_name: 'One' },
+  rb1: { position: 'RB', first_name: 'RB', last_name: 'One' },
+  wr1: { position: 'WR', first_name: 'WR', last_name: 'One' },
+  te1: { position: 'TE', first_name: 'TE', last_name: 'One' },
+  flex1: { position: 'FLEX', first_name: 'Flex', last_name: 'One' },
+  bench_qb: { position: 'QB', first_name: 'Bench', last_name: 'QB' },
+  taxi_rb: { position: 'RB', first_name: 'Taxi', last_name: 'RB' },
+}
+
+const defaultValues: Record<string, number> = {
+  qb1: 5000, rb1: 4000, wr1: 3500, te1: 2000, flex1: 1500, bench_qb: 1000, taxi_rb: 800,
+}
+
+// ---------------------------------------------------------------------------
+// build()
+// ---------------------------------------------------------------------------
+
+describe('TeamAnalysisService.build()', () => {
+  const service = makeService(defaultValues)
+
+  it('buckets starters by position', () => {
+    const roster = makeRoster(1, 'u1', ['qb1', 'rb1', 'wr1', 'te1'], ['qb1', 'rb1', 'wr1', 'te1'])
+    const [a] = service.build([roster], [makeUser('u1', 'Team A')], playerMap)
+    expect(a.qbValue).toBe(5000)
+    expect(a.rbValue).toBe(4000)
+    expect(a.wrValue).toBe(3500)
+    expect(a.teValue).toBe(2000)
+    expect(a.benchValue).toBe(0)
+    expect(a.taxiValue).toBe(0)
+  })
+
+  it('puts non-starter players on bench', () => {
+    const roster = makeRoster(1, 'u1', ['qb1', 'rb1', 'bench_qb'], ['qb1', 'rb1'])
+    const [a] = service.build([roster], [makeUser('u1', 'Team A')], playerMap)
+    expect(a.qbValue).toBe(5000)
+    expect(a.rbValue).toBe(4000)
+    expect(a.benchValue).toBe(1000) // bench_qb not a starter → bench
+  })
+
+  it('excludes reserve players from bench', () => {
+    const roster = makeRoster(1, 'u1', ['qb1', 'rb1'], ['qb1'], [], ['rb1'])
+    const [a] = service.build([roster], [makeUser('u1', 'Team A')], playerMap)
+    expect(a.benchValue).toBe(0)
+    expect(a.rbValue).toBe(0) // reserve not counted anywhere
+  })
+
+  it('puts taxi players in taxiValue only', () => {
+    const roster = makeRoster(1, 'u1', ['qb1', 'taxi_rb'], ['qb1'], ['taxi_rb'])
+    const [a] = service.build([roster], [makeUser('u1', 'Team A')], playerMap)
+    expect(a.taxiValue).toBe(800)
+    expect(a.rbValue).toBe(0)
+    expect(a.benchValue).toBe(0)
+  })
+
+  it('puts FLEX/unknown position players in bench regardless of starter status', () => {
+    const roster = makeRoster(1, 'u1', ['flex1'], ['flex1'])
+    const [a] = service.build([roster], [makeUser('u1', 'Team A')], playerMap)
+    expect(a.benchValue).toBe(1500)
+    expect(a.qbValue + a.rbValue + a.wrValue + a.teValue).toBe(0)
+  })
+
+  it('uses team_name metadata over display_name', () => {
+    const [a] = service.build([makeRoster(1, 'u1', [])], [makeUser('u1', 'JohnDoe', 'The Champs')], playerMap)
+    expect(a.teamName).toBe('The Champs')
+  })
+
+  it('falls back to display_name when no team_name metadata', () => {
+    const [a] = service.build([makeRoster(1, 'u1', [])], [makeUser('u1', 'JohnDoe')], playerMap)
+    expect(a.teamName).toBe('JohnDoe')
+  })
+
+  it('falls back to Roster #N when no user found', () => {
+    const [a] = service.build([makeRoster(1, 'u_missing', [])], [], playerMap)
+    expect(a.teamName).toBe('Roster #1')
+  })
+
+  it('skips players with value 0', () => {
+    const zeroService = makeService({})
+    const [a] = zeroService.build([makeRoster(1, 'u1', ['qb1', 'rb1'], ['qb1', 'rb1'])], [makeUser('u1', 'Team A')], playerMap)
+    expect(a.qbValue + a.rbValue).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// axisMaxes()
+// ---------------------------------------------------------------------------
+
+describe('TeamAnalysisService.axisMaxes()', () => {
+  const service = makeService()
+
+  it('returns per-axis max across all teams', () => {
+    const maxes = service.axisMaxes([
+      makeTeam(1, { qb: 5000, rb: 2000, wr: 3000, te: 1000, bench: 500 }),
+      makeTeam(2, { qb: 3000, rb: 4000, wr: 2500, te: 1500, bench: 800, taxi: 200 }),
+    ])
+    expect(maxes['QB']).toBe(5000)
+    expect(maxes['RB']).toBe(4000)
+    expect(maxes['WR']).toBe(3000)
+    expect(maxes['TE']).toBe(1500)
+    expect(maxes['Bench']).toBe(800)
+    expect(maxes['Taxi']).toBe(200)
+  })
+
+  it('returns zeros for empty team list', () => {
+    expect(Object.values(service.axisMaxes([])).every((v) => v === 0)).toBe(true)
+  })
+
+  it('handles a single team', () => {
+    const maxes = service.axisMaxes([makeTeam(1, { qb: 4000, rb: 3000 })])
+    expect(maxes['QB']).toBe(4000)
+    expect(maxes['RB']).toBe(3000)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// leagueAverageAxes()
+// ---------------------------------------------------------------------------
+
+describe('TeamAnalysisService.leagueAverageAxes()', () => {
+  const service = makeService()
+
+  it('computes per-axis averages across all teams', () => {
+    const avgMap = Object.fromEntries(
+      service.leagueAverageAxes([
+        makeTeam(1, { qb: 4000, rb: 3000, wr: 2000, te: 1000, bench: 500 }),
+        makeTeam(2, { qb: 2000, rb: 1000, wr: 4000, te: 3000, bench: 1500 }),
+      ]).map((a) => [a.label, a.value]),
+    )
+    expect(avgMap['QB']).toBe(3000)
+    expect(avgMap['RB']).toBe(2000)
+    expect(avgMap['WR']).toBe(3000)
+    expect(avgMap['TE']).toBe(2000)
+    expect(avgMap['Bench']).toBe(1000)
+    expect(avgMap['Taxi']).toBe(0)
+  })
+
+  it('returns zeros for empty team list', () => {
+    const avgs = service.leagueAverageAxes([])
+    expect(avgs.every((a) => a.value === 0)).toBe(true)
+    expect(avgs.map((a) => a.label)).toEqual(['QB', 'RB', 'WR', 'TE', 'Bench', 'Taxi'])
+  })
+
+  it('returns axes in canonical hex order', () => {
+    const avgs = service.leagueAverageAxes([makeTeam(1, { qb: 1, rb: 2, wr: 3, te: 4, bench: 5, taxi: 6 })])
+    expect(avgs.map((a) => a.label)).toEqual(['QB', 'RB', 'WR', 'TE', 'Bench', 'Taxi'])
+  })
+
+  it('rounds fractional averages to integer', () => {
+    const avgs = service.leagueAverageAxes([makeTeam(1, { qb: 3000 }), makeTeam(2, { qb: 2001 })])
+    const qb = avgs.find((a) => a.label === 'QB')!
+    expect(Number.isInteger(qb.value)).toBe(true)
+  })
+})

--- a/src/app/services/team-analysis.service.ts
+++ b/src/app/services/team-analysis.service.ts
@@ -1,0 +1,192 @@
+import { Injectable } from '@angular/core'
+import { forkJoin, map, Observable, switchMap } from 'rxjs'
+import { Roster } from '../models/roster.interface'
+import { User } from '../models/user.interface'
+import { HexAxis, HEX_AXIS_LABELS, TeamAnalysis, hexAxes } from '../models/team-analysis.model'
+import { LeagueService } from './league.service'
+import { PlayerService } from './player.service'
+import { PlayerValuesService } from './player-values.service'
+
+/**
+ * Builds per-team dynasty-value analyses for every roster in the home league.
+ * Port of iOS `TeamAnalysisBuilder` enum (TeamAnalysis.swift).
+ *
+ * Position bucketing rules (match iOS exactly):
+ * - Taxi players → taxiValue only; never counted in position axes.
+ * - Reserve players → excluded from bench bucket (they are IR, not bench).
+ * - Starters → bucketed by position (QB/RB/WR/TE); unknown/FLEX → bench.
+ * - Bench = not in starters AND not in reserve AND not in taxi.
+ * - Position resolved via PlayerService player map first, then
+ *   PlayerValuesService fallback (mirrors iOS `playerStore` → `valuesStore`).
+ */
+@Injectable({ providedIn: 'root' })
+export class TeamAnalysisService {
+  constructor(
+    private leagueService: LeagueService,
+    private playerService: PlayerService,
+    private valuesService: PlayerValuesService,
+  ) {}
+
+  /**
+   * Load rosters + users for the home league, then build analyses.
+   * Triggers a FantasyCalc values load if not yet cached.
+   */
+  buildForHomeLeague(): Observable<TeamAnalysis[]> {
+    const leagueId = this.leagueService.getWhitelistedLeagueId()
+
+    return forkJoin([
+      this.leagueService.findLeagueRosters(leagueId),
+      this.leagueService.findLeagueUsers(leagueId),
+      this.valuesService.load(),
+    ]).pipe(
+      switchMap(([rosters, users, _values]) =>
+        this.playerService
+          .getPlayerMap()
+          .pipe(map((playerMap) => this.build(rosters, users, playerMap))),
+      ),
+    )
+  }
+
+  /**
+   * Pure build function — builds analyses from already-loaded data.
+   * Port of iOS `TeamAnalysisBuilder.build(rosters:users:playerStore:valuesStore:)`.
+   */
+  build(
+    rosters: Roster[],
+    users: User[],
+    playerMap: Record<string, { position?: string; first_name?: string; last_name?: string }>,
+  ): TeamAnalysis[] {
+    const userById = new Map<string, User>(
+      users.filter((u) => !!u.user_id).map((u) => [u.user_id, u]),
+    )
+
+    return rosters.map((roster) => {
+      const starters = new Set(roster.starters ?? [])
+      const taxi = new Set(roster.taxi ?? [])
+      const reserve = new Set(roster.reserve ?? [])
+      const allRostered = roster.players ?? []
+
+      let qb = 0,
+        rb = 0,
+        wr = 0,
+        te = 0,
+        bench = 0,
+        taxiSum = 0
+
+      for (const pid of allRostered) {
+        const value = this.valuesService.value(pid)
+        if (value <= 0) continue
+
+        if (taxi.has(pid)) {
+          taxiSum += value
+          continue // taxi never counts toward starter buckets
+        }
+
+        // Position: player map first, FantasyCalc fallback (mirrors iOS)
+        const rawPos =
+          playerMap[pid]?.position ?? this.valuesService.position(pid) ?? '?'
+        const pos = rawPos.toUpperCase()
+
+        const onBench = !starters.has(pid) && !reserve.has(pid)
+
+        switch (pos) {
+          case 'QB':
+            if (onBench) {
+              bench += value
+            } else {
+              qb += value
+            }
+            break
+          case 'RB':
+            if (onBench) {
+              bench += value
+            } else {
+              rb += value
+            }
+            break
+          case 'WR':
+            if (onBench) {
+              bench += value
+            } else {
+              wr += value
+            }
+            break
+          case 'TE':
+            if (onBench) {
+              bench += value
+            } else {
+              te += value
+            }
+            break
+          default:
+            // FLEX-eligible / unknown → bench regardless of starter status.
+            // Mirrors iOS comment: "avoids polluting position axes."
+            bench += value
+        }
+      }
+
+      const owner = roster.owner_id ? userById.get(roster.owner_id) : undefined
+      const teamName =
+        owner?.metadata?.['team_name'] ??
+        owner?.display_name ??
+        `Roster #${roster.roster_id}`
+
+      return {
+        rosterId: roster.roster_id,
+        teamName: teamName as string,
+        userId: roster.owner_id ?? '',
+        avatarId: owner?.avatar ?? null,
+        qbValue: qb,
+        rbValue: rb,
+        wrValue: wr,
+        teValue: te,
+        benchValue: bench,
+        taxiValue: taxiSum,
+      } satisfies TeamAnalysis
+    })
+  }
+
+  /**
+   * League-wide max per axis. Normalizing against these maxes lets the
+   * chart render each vertex as a fraction of "best in league."
+   * Port of iOS `TeamAnalysisBuilder.axisMaxes(_:)`.
+   */
+  axisMaxes(teams: TeamAnalysis[]): Record<string, number> {
+    const max: Record<string, number> = Object.fromEntries(
+      HEX_AXIS_LABELS.map((l) => [l, 0]),
+    )
+    for (const team of teams) {
+      for (const axis of hexAxes(team)) {
+        if (axis.value > (max[axis.label] ?? 0)) {
+          max[axis.label] = axis.value
+        }
+      }
+    }
+    return max
+  }
+
+  /**
+   * League-wide average per axis, in canonical hex-axis order.
+   * Drives the dashed league-average overlay polygon.
+   * Port of iOS `TeamAnalysisBuilder.leagueAverageAxes(_:)`.
+   */
+  leagueAverageAxes(teams: TeamAnalysis[]): HexAxis[] {
+    if (teams.length === 0) {
+      return HEX_AXIS_LABELS.map((label) => ({ label, value: 0 }))
+    }
+
+    const sums: Record<string, number> = Object.fromEntries(
+      HEX_AXIS_LABELS.map((l) => [l, 0]),
+    )
+    for (const team of teams) {
+      for (const axis of hexAxes(team)) {
+        sums[axis.label] = (sums[axis.label] ?? 0) + axis.value
+      }
+    }
+
+    return HEX_AXIS_LABELS.map((label) => ({
+      label,
+      value: Math.round(sums[label] / teams.length),
+    }))
+  }
+}


### PR DESCRIPTION
## Summary

PR 8a of the s8 Team Analyzer stub. Data layer only — no UI components.

- **`PlayerValuesService`** — FantasyCalc dynasty-superflex fetch, 12h session cache (`shareReplay(1)`), `value(id)` / `position(id)` / `pickValue(name)` / `pickNames(forYears)` / `allPickNames` / `hasValues`. Single swappable `FANTASYCALC_ENDPOINT` constant. Port of iOS `PlayerValuesStore.swift`.
- **`player-value.model.ts`** — `FantasyCalcPlayerRaw`, `PlayerValue`, `parsePlayerValue`, `parseYearPrefix`. Port of iOS `PlayerValue.swift`.
- **`team-analysis.model.ts`** — `TeamAnalysis`, `HexAxis`, `HEX_AXIS_LABELS`, `TradeSide`, `ProposedTrade`, `TradeEvaluation`, `TradeVerdict` (discriminated union), `RecommendedTrade`, `PlayerSummary`, `SuggestedAddOn`, `FAIR_THRESHOLD`. Port of iOS `TeamAnalysis.swift` + `ProposedTrade.swift`.
- **`TeamAnalysisService`** — `build()` (taxi excluded from position buckets, bench = not starter/reserve/taxi, FLEX/unknown → bench), `axisMaxes()`, `leagueAverageAxes()`, `buildForHomeLeague()`. Port of iOS `TeamAnalysisBuilder`.
- **`RecommendedTradeService`** — `evaluate()`, `sideValue()`, `suggestBalance()`, `recommend()`. Preserves 5% `FAIR_THRESHOLD`, weak ≤0.85 / strong ≥1.05 bands, `myImprovement` cap, dedupe key, `limit` ranking. Port of iOS `TradeEvaluator` + `RecommendedTradeBuilder`.
- **`PlayerService.getPlayerMap()`** — public accessor for the cached Sleeper player map (one-line wrapper needed by `TeamAnalysisService`).
- **34 unit tests** across 3 spec files covering axis math, maxes, averages, trade verdict logic, side value, recommend weak/strong detection, dedup, and ranking. All compile clean under strict TypeScript.

## CORS gate

Verified before implementation: `curl -H "Origin: https://xomper.xomware.com" https://api.fantasycalc.com/values/current?...` returns `200 OK` with `access-control-allow-origin: *`. Direct browser calls are safe; no proxy needed.

## Notes

- `PlayerValuesService` also unblocks deferred s4 draft grades (future `s4b`).
- PR 8b (visual layer: SVG hexagon chart, 3-tab component, cards, routing, sidebar) follows.

## Test plan

- [ ] `ng build` passes (no new errors — pre-existing bundle budget warning only)
- [ ] `npx tsc -p tsconfig.spec.json --noEmit` clean
- [ ] `PlayerValuesService.load()` fetches FantasyCalc and populates `hasValues`
- [ ] `value()`, `pickValue()`, `allPickNames`, `pickNames(forYears)` return correct results
- [ ] `TeamAnalysisService.build()` correctly buckets starters/bench/taxi/reserve
- [ ] `axisMaxes()` returns per-axis league maxes; `leagueAverageAxes()` returns correct averages in canonical order
- [ ] `evaluate()` returns correct verdicts: empty / fair / sideAWins / sideBWins
- [ ] `recommend()` surfaces fair-value trades where I am weak / partner is surplus

Closes #94