### PR TITLE
#100 feat: s10 PR1 — Midnight Emerald theme foundation + mixins

### DIFF
--- a/docs/features/web-ios-parity/s10-midnight-emerald-sweep/EXECUTION_LOG.md
+++ b/docs/features/web-ios-parity/s10-midnight-emerald-sweep/EXECUTION_LOG.md
@@ -1,0 +1,91 @@
+# Execution Log — s10 Midnight Emerald Sweep (PR 1)
+
+**Date**: 2026-06-05
+**Branch**: `feature/100-midnight-emerald-foundation`
+**Issue**: #100
+**Executor**: Pixel
+
+---
+
+## Phase 0 — Pre-work
+
+- [x] GitHub issue created: #100 "web-ios-parity s10 (PR1): theme foundation + mixins", label `epic:web-ios-parity`
+- [x] Branch `feature/100-midnight-emerald-foundation` created off `948246b` (master, post-s9)
+- [x] In-flight check: no open PRs — clear
+- [x] s1–s9 all merged to master — confirmed via git log
+- [x] New shell is default (gate flipped post-s5)
+
+---
+
+## Step 1 — Extend tokens in `src/styles.scss`
+
+Added full `XomperColors` palette as `--xomper-*` CSS custom properties. Previous 6 tokens kept; 15 new tokens added; 4 gradient tokens added. Total: 25 custom properties.
+
+Hexes verified against `XomperColors.swift`.
+
+---
+
+## Step 2 — Create `src/styles/_theme.scss`
+
+New file. Mixins:
+- `xomper-gradient-bg` — midnight emerald gradient background (deepNavy → darkNavy → deepNavy, 180°)
+- `xomper-card` — standard card (bg-card, radius-lg, shadow-md)
+- `xomper-hero-card` — gold border (rgba champion-gold 0.4) + card gradient + hover lift
+- `xomper-section-divider` — red 3px top bar + uppercase tracked red h2 text
+- `xomper-subheader` — champion-gold h3 subheader
+- `xomper-chip` — gold pill chip (champion-gold bg, deep-navy text)
+- `xomper-chip-outline` — gold outline variant
+
+---
+
+## Step 3 — Fix StyledMarkdownComponent fallback hexes
+
+Bug: `--color-error-red` fallback was `#e53935` (off-palette). Real value: `#FF5252` (`errorRed`).
+Bug: `--color-champion-gold` fallback was `#f0c040` (off-palette). Real value: `#00FFAB` (`championGold`).
+
+Both also referencing old `--color-*` namespace instead of `--xomper-*`. Updated to `--xomper-accent-red` / `--xomper-champion-gold` with correct fallbacks. Also updated `--color-text-primary`, `--color-text-secondary` to `--xomper-text-primary`, `--xomper-text-secondary`.
+
+---
+
+## Step 4 — B1 Shell / Sidebar sweep
+
+- `shell-layout.component.scss`: gradient bg via `xomper-gradient-bg`, token pass on topbar/hamburger
+- `sidebar.component.scss`: token pass, active indicator gold left-bar added
+- `mobile-drawer.component.scss`: scrim opacity via token, panel shadow
+- `footer.component.scss`: already themed, minor token consolidation
+- `ambient-background.component.scss`: no change needed (SVG-driven)
+
+---
+
+## Step 5 — B2 Landing sweep
+
+- `landing.component.scss`: gradient bg via `xomper-gradient-bg`
+- `landing-headline-card`: already uses `$card-gradient` + gold border — converted to `xomper-hero-card` mixin
+- `landing-announcements-card`: off-palette `#ef4444` → `$accent-red` + `xomper-card` for rows
+- `landing-standings-scroll-card`: `xomper-card` on chips, `xomper-chip` for mine indicator
+- `landing-this-week-card` (matchups): `xomper-card` on rows
+- `landing-draft-countdown-card`: already gold-themed, minor token cleanup
+
+---
+
+## Step 6 — B5 AI Review sweep
+
+- `ai-review-list.component.scss`: off-palette `var(--color-*)` → `var(--xomper-*)`, `#f0c040` fallbacks → `#00FFAB`, skeleton rows tokenized
+- `ai-review-detail.component.scss`: `--color-surface` → `--xomper-bg-card`, `--color-border` → `$surface-light`, `xomper-hero-card` on header card, chip colors tokenized
+- `ai-report-card-row.component.scss`: `--color-surface` → `--xomper-bg-card`, gold fallback fixed, `xomper-card` mixin applied
+
+---
+
+## Build
+
+`npm run build` — result: TBD
+
+---
+
+## PR 2 Queue
+
+- B3: League sub-pages (standings, matchups, playoffs, world-cup, rulebook, scoring, league-settings, payouts, rule-proposals, draft-order)
+- B4: Draft tabs (draft-history, live, mocks, picks, recap)
+- B6: Admin portal (~18 sub-screens) — heaviest batch
+- B7: Team Analyzer (hexagon-chart, position-breakdown-card, recommended-trade-card)
+- B8: Misc (search, team, profile, settings, taxi-squad, matchup-history, link-sleeper, login, home, modals, toast, loader, confirm-dialog)

--- a/docs/features/web-ios-parity/s10-midnight-emerald-sweep/PLAN.md
+++ b/docs/features/web-ios-parity/s10-midnight-emerald-sweep/PLAN.md
@@ -1,7 +1,8 @@
 # Plan: Web ↔ iOS Parity — s10 Midnight Emerald Sweep
 
-**Status**: Draft
+**Status**: Ready
 **Created**: 2026-06-04
+**Last updated**: 2026-06-04
 **Epic**: [`../PLAN.md`](../PLAN.md)
 **Brainstorm**: [`../BRAINSTORM.md`](../BRAINSTORM.md)
 
@@ -9,68 +10,175 @@
 
 ## TL;DR
 
-Component-level visual port: dark gradient backgrounds, gold/red accent treatments, red `h2` headers, red dividers, typography pass. Tokens already exist from s1; this is the styling sweep. **Must be last** so feature PRs don't churn on visual review.
+The final stub. s1–s9 built every IA + feature surface on neutral/midnight backgrounds. This stub extends `src/styles.scss` CSS custom-property tokens to the **full `XomperColors` palette**, builds a shared `_theme.scss` mixins file (card, hero-card, section-divider, chip, gradient bg), and sweeps the **Midnight Emerald accent treatment** across every surface to match iOS and the email templates: dark gradient backgrounds, gold-bordered hero cards, gold CTA accents, red `h2` dividers + gold subheaders. **Pure visual — zero behavioral change.**
 
 ---
 
-## iOS source surfaces
+## Approach
 
-- `Xomper/Core/Theme/XomperColors.swift`
-- `Xomper/Core/Theme/XomperTheme.swift`
+Deferred to last on purpose (epic Option C, Decision D-E theme-deferral) so feature PRs never churned on visual review. The SCSS variable layer in `src/styles/_variables.scss` **already mirrors the full palette** — the work is not redefining colors, it's (1) exposing the full palette as `--xomper-*` CSS custom properties, (2) extracting the accent treatment that s5–s9 emerged ad-hoc into shared mixins, and (3) applying those mixins consistently across surfaces that currently range from "mostly themed" (Landing, League) to "raw hardcoded greys" (Admin).
 
-## Web surfaces touched
-
-- `styles.scss` — extend the token namespace established in s1 (typography, spacing, gradients, shadows)
-- Every feature component shipped in s1–s9 — apply tokens + Midnight Emerald treatments
-- Existing components (toolbar refs removed by s1; sidebar, drawer, modals, cards, tables)
-- Email-template-style elements: red `h2`, red dividers, gold accents
-- Typography pass: Dynamic Type parity (CSS `clamp()` or rem scaling)
+Reference treatment is the iOS email templates + `StyledMarkdownComponent`: red 3px `h2` top-bar dividers, uppercase tracked red `h2` text, gold `h3` subheaders, gold-bordered hero cards over a card gradient.
 
 ---
 
-## Dependencies
+## Scope
 
-**Every prior stub** (s1 through s9). This stub explicitly waits for the last feature surface to merge so visual review happens once, not per-PR.
+### In scope
+- Extend `src/styles.scss` `:root` tokens from the current 6 to the **full `XomperColors` palette** (`--xomper-*` namespace, established s1).
+- Build `src/styles/_theme.scss` — shared mixins: `xomper-card`, `xomper-hero-card`, `xomper-section-divider`, `xomper-chip`, `xomper-gradient-bg`, `xomper-subheader`.
+- Apply the accent treatment app-wide: dark gradient backgrounds, gold accents on cards/CTAs, red `h2` dividers + gold subheaders, gold-bordered hero cards, consistent corner radii + spacing from `XomperTheme`, typography pass.
+- Fix `StyledMarkdownComponent` fallback hexes — currently `#e53935`/`#f0c040`, must be palette `#ff4757`/`#00ffab`.
 
----
-
-## Open questions for `/plan` to resolve
-
-- [ ] **Sweep granularity**: one massive PR (matches D-A `/ultrareview` per stub) or split by section (Play / Team / League / Admin / Search / Landing)? Single PR has highest review burden; split adds coordination cost.
-- [ ] **Typography mapping**: iOS uses Dynamic Type. Web — pure `rem` + user font-size respect, `clamp()` for responsive scaling, or both? Affects accessibility story.
-- [ ] **Component primitives**: do we extract shared primitives (`Card`, `Divider`, `SectionHeader`) as part of this sweep, or apply the treatment inline per component?
-- [ ] **Animation/motion**: iOS has subtle springs on tap/transitions. Does this sweep ship motion parity (CSS transitions, `prefers-reduced-motion` respect) or stay static?
-
----
-
-## Out of scope
-
-- Any new feature surfaces — they all shipped in s1–s9.
-- Functional behavior changes — visual-only sweep.
-- Backend changes. None required.
-- Reworking the marketing landing in `xomware-frontend`.
+### Out of scope
+- **No functional / behavioral changes** — pure visual.
+- No backend work (no Lambda, Supabase, infra).
+- No new features or surfaces — all shipped s1–s9.
+- Legacy toolbar / old components behind `?newShell=0` opt-out (deleted in the gate-removal follow-up — see Decisions).
+- Light mode (iOS is always-dark; web matches — dark only).
 
 ---
 
-## Backend contract dependencies
+## Token mapping (iOS `XomperColors` → CSS custom property → hex)
 
-| New service(s) | Backend contract used | New backend work? |
+Hexes read from `Xomper/Core/Theme/XomperColors.swift`.
+
+| iOS name | CSS custom property | Hex |
 |---|---|---|
-| — | — | No |
+| `deepNavy` | `--xomper-deep-navy` | `#050A08` |
+| `darkNavy` | `--xomper-dark-navy` | `#0C1612` |
+| `bgDark` | `--xomper-bg-dark` *(exists)* | `#030706` |
+| `bgCard` | `--xomper-bg-card` *(exists)* | `#0A1610` |
+| `bgCardHover` | `--xomper-bg-card-hover` | `#14271E` |
+| `bgInput` | `--xomper-bg-input` | `#14271E` |
+| `championGold` | `--xomper-champion-gold` *(exists)* | `#00FFAB` |
+| `steelBlue` | `--xomper-steel-blue` | `#00E89D` |
+| `accentRed` | `--xomper-accent-red` *(exists)* | `#FF4757` |
+| `textPrimary` | `--xomper-text-primary` *(exists)* | `#F0F5F0` |
+| `textSecondary` | `--xomper-text-secondary` | `#8FADA0` |
+| `textMuted` | `--xomper-text-muted` *(exists)* | `#4A6B5C` |
+| `successGreen` | `--xomper-success-green` | `#00E676` |
+| `errorRed` | `--xomper-error-red` | `#FF5252` |
+| `surfaceLight` | `--xomper-surface-light` | `#1A2E26` |
+| `legacyRed` | `--xomper-legacy-red` | `#BF0A0A` |
+| `legacyBlue` | `--xomper-legacy-blue` | `#1B8EDC` |
+| `bgGradient` | `--xomper-bg-gradient` | `deepNavy → darkNavy → deepNavy` (180°) |
+| `cardGradient` | `--xomper-card-gradient` | `0C1612@.97 → 050A08@.97` (135°) |
+| `goldAccentGradient` | `--xomper-gold-accent` | `championGold → steelBlue` (90°) |
+| `redAccentGradient` | `--xomper-red-accent` | `accentRed → #FF6B7A` (90°) |
+
+Spacing / radius from `XomperTheme.swift`: spacing `2/4/8/16/24/32/48/64`; radius `sm 4 / md 8 / lg 12 / xl 16 / full 9999`. (`_variables.scss` already carries these; `_theme.scss` consumes them.)
+
+---
+
+## Sweep inventory (batches)
+
+70 `.scss` files. Grouped by surface; deltas noted.
+
+| Batch | Surfaces | Key visual deltas | State today |
+|---|---|---|---|
+| **B0 Foundation** | `styles.scss`, new `_theme.scss`, `styled-markdown` | Full token set; mixins; fix md `h2`/`h3` fallback hexes | tokens partial |
+| **B1 Shell / Sidebar** | `shell-layout`, `sidebar`, `mobile-drawer`, `app.component`, `footer`, `ambient-background` | Gradient bg, gold active-nav indicator, surface-light dividers | mostly themed |
+| **B2 Landing** | `landing` + 5 `cards/*` | Hero card → gold border + card gradient; gold chips; consistent radii | mostly themed (ad-hoc → mixin) |
+| **B3 League sub-pages** | `league`, `standings`, `matchups`, `playoffs`, `world-cup`, `rulebook`, `scoring`, `league-settings`, `payouts`, `rule-proposals`, `draft-order` | Red toggle/divider treatment, gold rank/winner accents, section dividers | partial |
+| **B4 Draft tabs** | `draft-history`, `live`, `mocks`, `picks`, `recap` | Card treatment on pick rows, gold round headers | partial |
+| **B5 AI Review** | `ai-review-list`, `ai-review-detail`, `ai-report-card-row` | Gold hero card, red `h2` dividers via styled-markdown | mostly themed |
+| **B6 Admin portal** | `admin` + ~18 `admin/**` sub-screens | Replace raw `rgba(255,255,255,*)` / `#f87171` with tokens; card + chip treatment | **mostly raw — heaviest** |
+| **B7 Team Analyzer** | `team-analyzer`, `hexagon-chart`, `position-breakdown-card`, `recommended-trade-card` | Gold-stroked hexagon, gold-border cards | partial |
+| **B8 Search + misc** | `search`, `team`, `profile`, `settings`, `taxi-squad`, `matchup-history`, `link-sleeper`, `login`, `home`, modals, `toast`, `loader`, `confirm-dialog` | Token pass, card + chip treatment, gradient bg | mixed |
+
+---
+
+## Phase 0 — pre-work
+
+- [ ] **Create GitHub sub-issue** under epic, label `epic:web-ios-parity`. Branch `style/<issue>-midnight-emerald-sweep` off master (`948246b`).
+- [ ] **In-flight check** — confirm no open web PRs touching `.scss`, `_variables.scss`, `_mixins.scss`, or `styles.scss`. Any in-flight must merge/close first (sweep touches ~70 files → catastrophic rebase otherwise).
+- [ ] **Confirm all s1–s9 stubs merged** to master (epic dependency — this is last).
+- [ ] **Confirm new shell is default** (gate flipped post-s5). Legacy toolbar surfaces explicitly skipped.
+
+---
+
+## Affected files / components
+
+Large diff, **low risk** — pure presentation, no `.ts`/`.html` logic touched. ~70 `.scss` files plus 2 new/extended foundation files.
+
+| File / component | Change | Why |
+|---|---|---|
+| `src/styles.scss` | Extend `:root` to full palette tokens | Single source for `--xomper-*` |
+| `src/styles/_theme.scss` *(new)* | Shared accent mixins | DRY the treatment across 70 files |
+| `src/app/components/styled-markdown/*.scss` | Fix `h2`/`h3` fallback hexes to palette | Canonical brand `h2`/`h3` |
+| `src/app/**/*.component.scss` (~67) | Apply mixins + tokens per batch | The sweep |
+
+### PR strategy — split recommended
+
+`_variables.scss` already holds the palette, so per-file churn is moderate (token swaps + mixin includes), **not** full rewrites — but B6 Admin is near-raw and large. Survey puts total churn at **~1,500–2,200 LoC of SCSS** across 70 files. That straddles the split threshold.
+
+**Recommendation: split into 2 PRs.**
+- **PR 1 — Foundation + shared:** B0 + B1 + B2 + B5 (tokens, `_theme.scss`, shell, the already-mostly-themed surfaces that exercise the mixins). Reviewable, establishes the pattern, low risk.
+- **PR 2 — Per-feature sweep:** B3 + B4 + B6 + B7 + B8 (the bulk, including the heavy Admin batch). Reviewed against the now-locked mixin API.
+
+`/ultrareview` runs before **each** PR (Decision D-A).
+
+---
+
+## Implementation steps
+
+- [ ] **1 — Extend tokens.** Add the full palette + gradients to `:root` in `src/styles.scss` (table above). Keep existing 6; do not rename.
+- [ ] **2 — Build `_theme.scss`.** Mixins: `xomper-card`, `xomper-hero-card` (gold border + card gradient + hover lift), `xomper-section-divider` (red 3px bar), `xomper-subheader` (gold uppercase), `xomper-chip` (gold pill), `xomper-gradient-bg`. Consume `_variables.scss` values; map 1:1 to `XomperTheme` radii/spacing.
+- [ ] **3 — Fix StyledMarkdown.** Swap fallback hexes to palette (`--xomper-error-red`/`#FF5252`, `--xomper-champion-gold`/`#00FFAB`). This is the canonical `h2`/`h3` reference all other dividers point at.
+- [ ] **4 — Sweep B1 Shell/Sidebar** → smoke test → visual check.
+- [ ] **5 — Sweep B2 Landing** (replace ad-hoc gold-border with `xomper-hero-card`) → smoke test.
+- [ ] **6 — Sweep B5 AI Review** → smoke test.
+- [ ] **7 — Build PR 1, `/ultrareview`, open PR** (`Closes #<issue-part-1>` or single issue w/ checklist).
+- [ ] **8 — Sweep B3 League sub-pages** → smoke test each route.
+- [ ] **9 — Sweep B4 Draft tabs** → smoke test.
+- [ ] **10 — Sweep B6 Admin** (heaviest — replace raw greys with tokens, apply card/chip mixins) → smoke test each sub-screen.
+- [ ] **11 — Sweep B7 Team Analyzer** (gold hexagon stroke) → smoke test.
+- [ ] **12 — Sweep B8 Search + misc** (incl. modals, toast, loader) → smoke test.
+- [ ] **13 — Full build** (`ng build`) — confirm no SCSS compile errors, no unused-import warnings.
+- [ ] **14 — `/ultrareview`, open PR 2.**
+
+---
+
+## Decisions to surface
+
+- **Single PR vs split** → **Split (2 PRs).** ~1,500–2,200 LoC churn over 70 files; foundation+shared first locks the mixin API, then the bulk per-feature sweep reviews against it. Single PR would be unreviewable for a solo maintainer.
+- **Mixins vs utility classes vs per-component** → **Shared `_theme.scss` mixins.** Codebase already uses `@import 'styles/mixins'` and `@include` heavily (`card`, `glass-card`, `button-primary`). Mixins fit the existing convention, avoid global utility-class specificity surprises, and keep the accent treatment in one editable place.
+- **Touch legacy toolbar / `?newShell=0` components?** → **Skip.** Being deleted in the gate-removal follow-up; theming them is wasted churn.
+- **Dark-mode-only?** → **Confirmed dark only.** iOS is always-dark; no light-mode tokens, no `prefers-color-scheme`.
+
+---
+
+## Risks / tradeoffs
+
+- **Visual regression** — no behavioral test catches CSS. *Mitigation:* per-batch manual smoke test + `/ultrareview` per PR; batching keeps each review surface small.
+- **Specificity wars** with existing component SCSS (Admin's hardcoded `rgba`/`#hex` rules may out-rank mixin output). *Mitigation:* mixins emit plain property sets (no inflated selectors); replace conflicting hardcoded rules in-place rather than layering over them.
+- **Large diff hard to review.** *Mitigation:* shared mixins shrink per-file diffs to includes + token swaps; 2-PR split + batch ordering.
+- **Token drift** — `_variables.scss` (SCSS) and `:root` (CSS custom props) both hold the palette. *Mitigation:* `:root` interpolates `#{$var}` from `_variables.scss` (already the pattern) — single source, no duplicate hexes.
+
+---
+
+## Open questions
+
+- [ ] Should `_variables.scss` SCSS vars eventually be *replaced* by `var(--xomper-*)` references (one true source), or do we keep the dual layer (SCSS for compile-time `darken()`/`rgba()`, CSS props for runtime)? Lean: **keep dual** this stub; consolidation is a separate refactor.
+- [ ] Does the gold hexagon stroke (B7) need a runtime CSS-var-driven `stroke` on the SVG, or is a static themed value fine for a single always-dark theme? Lean: **static**.
 
 ---
 
 ## Success criteria
 
-- Dark gradient backgrounds match iOS `XomperColors.background`.
-- `h2` headers render in the accent red used in iOS email templates.
-- Dividers use the league-rules-style red treatment.
-- Champion gold appears on highlight elements (winner badges, primary CTAs) per iOS.
-- Typography respects user font-size preferences and scales responsively.
-- Visual diff vs. iOS screenshots is within the agreed tolerance (set during plan).
+- `src/styles.scss` `:root` exposes the full `XomperColors` palette as `--xomper-*` tokens (21 entries), hexes matching the Swift source exactly.
+- `_theme.scss` exists; hero cards across the app render a gold border over the card gradient via `xomper-hero-card` (Landing headline, AI Review, Team Analyzer parity).
+- Every `h2` section divider renders the red 3px top-bar + uppercase tracked red text; `h3` subheaders render champion-gold — matching the email templates and `StyledMarkdownComponent`.
+- App background is the Midnight Emerald gradient (`deepNavy → darkNavy → deepNavy`) on every routed surface.
+- Admin portal no longer uses raw `rgba(255,255,255,*)` / off-palette hexes — fully tokenized.
+- `ng build` compiles clean; zero behavioral/logic diffs (`.ts`/`.html` untouched except where a class rename is unavoidable).
+- Visual parity with iOS confirmed via per-batch manual review under `/ultrareview`.
 
 ---
 
 ## Next step
 
-Run `/plan s10-midnight-emerald-sweep` to expand this skeleton into implementation-level detail.
+```
+/execute s10-midnight-emerald-sweep
+```

--- a/src/app/components/ai-report-card-row/ai-report-card-row.component.scss
+++ b/src/app/components/ai-report-card-row/ai-report-card-row.component.scss
@@ -1,18 +1,23 @@
+@import 'styles/variables';
+@import 'styles/theme';
+
+// s10: was --color-surface/#1e2d2a (off-palette). Now xomper-card mixin + xomper-* tokens.
 .card-row {
+  @include xomper-card;
+
   display: block;
   width: 100%;
-  background: var(--color-surface, #1e2d2a);
-  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
-  border-radius: 10px;
+  border: 1px solid rgba($surface-light, 0.4);
   padding: 14px 16px;
   cursor: pointer;
   text-align: left;
-  transition: background 0.15s ease;
+  transition: background $transition-fast, border-color $transition-fast;
 
   &:hover,
   &:focus-visible {
-    background: var(--color-surface-hover, rgba(255, 255, 255, 0.05));
-    outline: 2px solid var(--color-champion-gold, #f0c040);
+    background: var(--xomper-bg-card-hover, #{$bg-card-hover});
+    border-color: rgba($champion-gold, 0.3);
+    outline: 2px solid var(--xomper-champion-gold, #{$champion-gold});
     outline-offset: 2px;
   }
 }
@@ -26,33 +31,31 @@
 }
 
 .card-row__chip {
-  font-size: 0.65rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  padding: 2px 7px;
-  border-radius: 4px;
-  text-transform: uppercase;
-  white-space: nowrap;
+  @include xomper-chip;
+
+  border-radius: $radius-sm;
+  // Per-type color overridden via [style.background] binding in template
 }
 
 .card-row__period {
-  color: var(--color-text-secondary, rgba(255, 255, 255, 0.65));
+  // s10: --color-text-secondary → --xomper-text-secondary
+  color: var(--xomper-text-secondary, #{$text-secondary});
   font-size: 0.8rem;
   font-weight: 500;
 }
 
 .card-row__date {
   margin-left: auto;
-  color: var(--color-text-tertiary, rgba(255, 255, 255, 0.4));
+  color: var(--xomper-text-muted, #{$text-muted});
   font-size: 0.75rem;
 }
 
 .card-row__snippet {
-  color: var(--color-text-primary, #ffffff);
+  // s10: --color-text-primary → --xomper-text-primary
+  color: var(--xomper-text-primary, #{$text-primary});
   font-size: 0.85rem;
   line-height: 1.45;
   margin: 0 0 8px;
-  // 3-line clamp
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
@@ -65,5 +68,5 @@
 }
 
 .card-row__chevron {
-  color: var(--color-text-tertiary, rgba(255, 255, 255, 0.4));
+  color: var(--xomper-text-muted, #{$text-muted});
 }

--- a/src/app/components/mobile-drawer/mobile-drawer.component.scss
+++ b/src/app/components/mobile-drawer/mobile-drawer.component.scss
@@ -22,7 +22,8 @@ $transition-drawer: 280ms cubic-bezier(0.4, 0, 0.2, 1);
   pointer-events: none;
 
   &.scrim--visible {
-    background: rgba(0, 0, 0, 0.6);
+    // s10: deep-navy tinted scrim instead of pure black
+    background: rgba($deep-navy, 0.75);
     pointer-events: auto;
     cursor: pointer;
   }
@@ -38,9 +39,10 @@ $transition-drawer: 280ms cubic-bezier(0.4, 0, 0.2, 1);
   z-index: $z-modal;
   transform: translateX(-100%);
   transition: transform $transition-drawer;
-  // The sidebar component handles its own bg; the panel is just the container
   display: flex;
   flex-direction: column;
+  // s10: panel shadow so it reads against the gradient bg
+  box-shadow: $shadow-xl;
 
   &.drawer-panel--open {
     transform: translateX(0);

--- a/src/app/components/shell-layout/shell-layout.component.scss
+++ b/src/app/components/shell-layout/shell-layout.component.scss
@@ -1,9 +1,11 @@
 @import 'src/styles/variables';
+@import 'src/styles/theme';
 
 .shell {
   display: flex;
   min-height: 100vh;
-  background: var(--xomper-bg-dark, $bg-dark);
+  // s10: full Midnight Emerald gradient background
+  background: $bg-gradient;
 
   &__sidebar {
     // sidebar component manages its own width (260px); this just ensures it is
@@ -32,7 +34,7 @@
     align-items: center;
     gap: $spacing-md;
     padding: $spacing-sm $spacing-md;
-    background: var(--xomper-bg-card, $bg-card);
+    background: var(--xomper-bg-card, #{$bg-card});
     border-bottom: 1px solid $surface-light;
     height: 56px;
     flex-shrink: 0;
@@ -41,7 +43,7 @@
   &__topbar-title {
     font-family: $font-display;
     font-size: $text-xl;
-    color: var(--xomper-champion-gold, $champion-gold);
+    color: var(--xomper-champion-gold, #{$champion-gold});
     letter-spacing: 0.05em;
   }
 }
@@ -60,9 +62,11 @@
   cursor: pointer;
   font-size: 1.1rem;
   flex-shrink: 0;
+  color: var(--xomper-text-primary, #{$text-primary});
+  transition: background $transition-fast;
 
   &:hover {
-    background: $bg-card-hover;
+    background: var(--xomper-bg-card-hover, #{$bg-card-hover});
   }
 }
 
@@ -81,16 +85,17 @@
   padding: 6px;
   margin: 0;
   flex-shrink: 0;
+  transition: background $transition-fast;
 
   &:hover {
-    background: $bg-card-hover;
+    background: var(--xomper-bg-card-hover, #{$bg-card-hover});
   }
 
   &__line {
     display: block;
     width: 100%;
     height: 2px;
-    background: var(--xomper-text-primary, $text-primary);
+    background: var(--xomper-text-primary, #{$text-primary});
     border-radius: 2px;
   }
 }

--- a/src/app/components/sidebar/sidebar.component.scss
+++ b/src/app/components/sidebar/sidebar.component.scss
@@ -6,7 +6,7 @@
   width: 260px;
   min-width: 260px;
   height: 100%;
-  background: var(--xomper-bg-card, $bg-card);
+  background: var(--xomper-bg-card, #{$bg-card});
   border-right: 1px solid $surface-light;
   overflow-y: auto;
   padding: $spacing-md 0;
@@ -31,10 +31,11 @@
   border-radius: $radius-sm;
   text-decoration: none;
   font-size: 1rem;
+  color: var(--xomper-text-primary, #{$text-primary});
   transition: background $transition-fast;
 
   &:hover {
-    background: $bg-card-hover;
+    background: var(--xomper-bg-card-hover, #{$bg-card-hover});
   }
 }
 
@@ -46,11 +47,11 @@
   margin: 0;
   border-radius: $radius-md;
   text-decoration: none;
-  color: var(--xomper-text-primary, $text-primary);
+  color: var(--xomper-text-primary, #{$text-primary});
   transition: background $transition-fast;
 
   &:hover {
-    background: $bg-card-hover;
+    background: var(--xomper-bg-card-hover, #{$bg-card-hover});
   }
 }
 
@@ -59,7 +60,7 @@
   height: 36px;
   border-radius: $radius-full;
   overflow: hidden;
-  background: $bg-card-hover;
+  background: var(--xomper-bg-card-hover, #{$bg-card-hover});
   flex-shrink: 0;
   display: flex;
   align-items: center;
@@ -75,7 +76,7 @@
 .avatar-initials {
   font-size: $text-sm;
   font-weight: 600;
-  color: var(--xomper-champion-gold, $champion-gold);
+  color: var(--xomper-champion-gold, #{$champion-gold});
 }
 
 .profile-name {
@@ -84,6 +85,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  color: var(--xomper-text-primary, #{$text-primary});
 }
 
 // ---- Sections ----
@@ -102,7 +104,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--xomper-text-muted, $text-muted);
+  color: var(--xomper-text-muted, #{$text-muted});
   padding: $spacing-xs $spacing-sm;
   margin-bottom: $spacing-xs;
 }
@@ -121,20 +123,33 @@ ul {
   padding: $spacing-xs $spacing-sm;
   border-radius: $radius-sm;
   text-decoration: none;
-  color: var(--xomper-text-primary, $text-primary);
+  color: var(--xomper-text-primary, #{$text-primary});
   font-size: $text-sm;
   transition: background $transition-fast, color $transition-fast;
   width: 100%;
+  position: relative;
 
   &:hover {
-    background: $bg-card-hover;
-    color: var(--xomper-champion-gold, $champion-gold);
+    background: var(--xomper-bg-card-hover, #{$bg-card-hover});
+    color: var(--xomper-champion-gold, #{$champion-gold});
   }
 
+  // s10: gold left-bar active indicator (matches iOS sidebar active state)
   &.entry--active {
-    background: $bg-card-hover;
-    color: var(--xomper-champion-gold, $champion-gold);
+    background: var(--xomper-bg-card-hover, #{$bg-card-hover});
+    color: var(--xomper-champion-gold, #{$champion-gold});
     font-weight: 600;
+
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 4px;
+      bottom: 4px;
+      width: 3px;
+      background: var(--xomper-champion-gold, #{$champion-gold});
+      border-radius: 0 2px 2px 0;
+    }
   }
 }
 

--- a/src/app/components/styled-markdown/styled-markdown.component.scss
+++ b/src/app/components/styled-markdown/styled-markdown.component.scss
@@ -1,10 +1,12 @@
+@import 'styles/variables';
+
 .styled-markdown {
   width: 100%;
 }
 
 // h1 — big white title (matches iOS Text(.title2.weight(.bold)))
 .md-h1 {
-  color: var(--color-text-primary, #ffffff);
+  color: var(--xomper-text-primary, #{$text-primary});
   font-size: 1.35rem;
   font-weight: 700;
   margin: 12px 0 8px;
@@ -12,7 +14,7 @@
 }
 
 // h2 — red 3px top bar + uppercase red text with letter-spacing
-// (matches iOS Rectangle.fill(errorRed) + Text.uppercased().tracking(2))
+// (matches iOS Rectangle.fill(accentRed) + Text.uppercased().tracking(2))
 .md-h2-wrapper {
   margin-top: 28px;
   margin-bottom: 10px;
@@ -20,13 +22,16 @@
 
 .md-h2-bar {
   height: 3px;
-  background: var(--color-error-red, #e53935);
+  // BUG FIX s10: was #e53935 (off-palette). Correct: accentRed #FF4757.
+  // errorRed (#FF5252) used here per plan note — the h2 divider maps to accentRed.
+  background: var(--xomper-accent-red, #{$accent-red});
   width: 100%;
   margin-bottom: 0;
 }
 
 .md-h2 {
-  color: var(--color-error-red, #e53935);
+  // BUG FIX s10: was #e53935 (off-palette). Correct: accentRed #FF4757.
+  color: var(--xomper-accent-red, #{$accent-red});
   font-size: 1.05rem;
   font-weight: 900;
   text-transform: uppercase;
@@ -37,7 +42,8 @@
 
 // h3 — gold subheader (matches iOS championGold foreground)
 .md-h3 {
-  color: var(--color-champion-gold, #f0c040);
+  // BUG FIX s10: was #f0c040 (off-palette). Correct: championGold #00FFAB.
+  color: var(--xomper-champion-gold, #{$champion-gold});
   font-size: 0.95rem;
   font-weight: 700;
   margin: 14px 0 4px;
@@ -57,32 +63,33 @@
   width: 3px;
   min-height: 1.2em;
   align-self: stretch;
-  background: var(--color-champion-gold, #f0c040);
+  // BUG FIX s10: was #f0c040 (off-palette). Correct: championGold #00FFAB.
+  background: var(--xomper-champion-gold, #{$champion-gold});
   border-radius: 2px;
 }
 
 .md-quote__body {
   font-style: italic;
-  color: var(--color-text-secondary, rgba(255, 255, 255, 0.65));
+  color: var(--xomper-text-secondary, #{$text-secondary});
   margin: 0;
   line-height: 1.5;
   font-size: 0.9rem;
 
   strong {
-    color: var(--color-text-primary, #ffffff);
+    color: var(--xomper-text-primary, #{$text-primary});
     font-style: normal;
   }
 }
 
 // paragraph — body text; **bold** rendered as <strong>
 .md-paragraph {
-  color: var(--color-text-primary, #ffffff);
+  color: var(--xomper-text-primary, #{$text-primary});
   font-size: 0.9rem;
   line-height: 1.5;
   margin-bottom: 12px;
 
   strong {
-    color: var(--color-text-primary, #ffffff);
+    color: var(--xomper-text-primary, #{$text-primary});
     font-weight: 700;
   }
 }

--- a/src/app/pages/ai-review/detail/ai-review-detail.component.scss
+++ b/src/app/pages/ai-review/detail/ai-review-detail.component.scss
@@ -1,3 +1,6 @@
+@import 'styles/variables';
+@import 'styles/theme';
+
 .ai-review-detail {
   max-width: 760px;
   margin: 0 auto;
@@ -11,14 +14,17 @@
   gap: 6px;
   background: transparent;
   border: none;
-  color: var(--color-text-secondary, rgba(255, 255, 255, 0.6));
+  // s10: --color-text-secondary → --xomper-text-secondary
+  color: var(--xomper-text-secondary, #{$text-secondary});
   font-size: 0.875rem;
   cursor: pointer;
   padding: 8px 0;
   margin-bottom: 20px;
-  transition: color 0.15s;
+  transition: color $transition-fast;
 
-  &:hover { color: var(--color-text-primary, #ffffff); }
+  &:hover {
+    color: var(--xomper-text-primary, #{$text-primary});
+  }
 }
 
 // Loading skeleton
@@ -30,12 +36,12 @@
 }
 
 .skeleton {
-  border-radius: 8px;
+  border-radius: $radius-md;
   background: linear-gradient(
     90deg,
-    rgba(255,255,255,0.04) 0%,
-    rgba(255,255,255,0.08) 50%,
-    rgba(255,255,255,0.04) 100%
+    rgba($bg-card-hover, 0.6) 0%,
+    rgba($surface-light, 0.4) 50%,
+    rgba($bg-card-hover, 0.6) 100%
   );
   background-size: 200% 100%;
   animation: shimmer 1.4s infinite;
@@ -56,28 +62,32 @@
 .ai-review-detail__not-found {
   text-align: center;
   padding: 64px 0;
-  color: var(--color-text-secondary, rgba(255, 255, 255, 0.6));
+  color: var(--xomper-text-secondary, #{$text-secondary});
 
   p { margin: 0 0 16px; }
 }
 
 .btn-back {
   background: transparent;
-  border: 1px solid var(--color-text-secondary, rgba(255,255,255,0.3));
-  color: var(--color-text-secondary, rgba(255,255,255,0.6));
+  border: 1px solid rgba($surface-light, 0.6);
+  color: var(--xomper-text-secondary, #{$text-secondary});
   padding: 8px 20px;
-  border-radius: 6px;
+  border-radius: $radius-md;
   cursor: pointer;
   font-size: 0.85rem;
+  transition: border-color $transition-fast, color $transition-fast;
 
-  &:hover { border-color: var(--color-text-primary, #fff); color: var(--color-text-primary, #fff); }
+  &:hover {
+    border-color: $text-primary;
+    color: var(--xomper-text-primary, #{$text-primary});
+  }
 }
 
-// Header card
+// Header card — hero treatment (gold border, card gradient)
+// s10: was --color-surface/#1e2d2a (off-palette), now xomper-hero-card mixin
 .ai-review-detail__header-card {
-  background: var(--color-surface, #1e2d2a);
-  border: 1px solid var(--color-border, rgba(255,255,255,0.08));
-  border-radius: 12px;
+  @include xomper-hero-card;
+
   padding: 18px 20px;
   margin-bottom: 12px;
 }
@@ -91,33 +101,31 @@
 }
 
 .ai-review-detail__chip {
-  font-size: 0.65rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  padding: 3px 9px;
-  border-radius: 5px;
-  color: #1a1a1a;
-  white-space: nowrap;
+  @include xomper-chip;
+
+  border-radius: $radius-sm;
+  // Color override per chip type (set via [style.background] binding in template)
+  // Base chip text is deep-navy — already set by mixin
 }
 
 .ai-review-detail__period {
-  color: var(--color-text-primary, #ffffff);
+  color: var(--xomper-text-primary, #{$text-primary});
   font-size: 1rem;
   font-weight: 600;
 }
 
 .ai-review-detail__date {
-  color: var(--color-text-secondary, rgba(255, 255, 255, 0.55));
+  color: var(--xomper-text-secondary, #{$text-secondary});
   font-size: 0.8rem;
   margin: 0;
 }
 
-// Body card
+// Body card — standard card
+// s10: was --color-surface/#1e2d2a (off-palette), now xomper-card mixin
 .ai-review-detail__body-card {
-  background: var(--color-surface, #1e2d2a);
-  border: 1px solid var(--color-border, rgba(255,255,255,0.08));
-  border-radius: 12px;
+  @include xomper-card;
+
+  border: 1px solid rgba($surface-light, 0.4);
   padding: 20px;
   margin-bottom: 12px;
 }
@@ -131,9 +139,9 @@
 }
 
 .ai-review-detail__meta-tag {
-  color: var(--color-text-tertiary, rgba(255,255,255,0.35));
+  color: var(--xomper-text-muted, #{$text-muted});
   font-size: 0.72rem;
-  background: rgba(255,255,255,0.04);
+  background: rgba($surface-light, 0.2);
   padding: 3px 8px;
-  border-radius: 4px;
+  border-radius: $radius-sm;
 }

--- a/src/app/pages/ai-review/list/ai-review-list.component.scss
+++ b/src/app/pages/ai-review/list/ai-review-list.component.scss
@@ -1,3 +1,6 @@
+@import 'styles/variables';
+@import 'styles/theme';
+
 .ai-review-list {
   max-width: 760px;
   margin: 0 auto;
@@ -9,19 +12,21 @@
 }
 
 .ai-review-list__title {
-  color: var(--color-text-primary, #ffffff);
+  // s10: --color-text-primary → --xomper-text-primary; fallback updated
+  color: var(--xomper-text-primary, #{$text-primary});
   font-size: 1.6rem;
   font-weight: 700;
   margin: 0 0 4px;
 }
 
 .ai-review-list__subtitle {
-  color: var(--color-text-secondary, rgba(255, 255, 255, 0.6));
+  // s10: --color-text-secondary → --xomper-text-secondary; fallback updated
+  color: var(--xomper-text-secondary, #{$text-secondary});
   font-size: 0.85rem;
   margin: 0;
 }
 
-// Skeleton rows
+// Skeleton rows — tokenized
 .ai-review-list__skeletons {
   display: flex;
   flex-direction: column;
@@ -30,12 +35,12 @@
 
 .skeleton-row {
   height: 90px;
-  border-radius: 10px;
+  border-radius: $radius-lg;
   background: linear-gradient(
     90deg,
-    rgba(255,255,255,0.04) 0%,
-    rgba(255,255,255,0.08) 50%,
-    rgba(255,255,255,0.04) 100%
+    rgba($bg-card-hover, 0.6) 0%,
+    rgba($surface-light, 0.4) 50%,
+    rgba($bg-card-hover, 0.6) 100%
   );
   background-size: 200% 100%;
   animation: shimmer 1.4s infinite;
@@ -50,29 +55,34 @@
 .ai-review-list__error {
   text-align: center;
   padding: 48px 0;
-  color: var(--color-text-secondary, rgba(255, 255, 255, 0.6));
+  color: var(--xomper-text-secondary, #{$text-secondary});
 
   p { margin: 0 0 16px; }
 }
 
 .btn-retry {
-  background: transparent;
-  border: 1px solid var(--color-champion-gold, #f0c040);
-  color: var(--color-champion-gold, #f0c040);
+  @include xomper-chip-outline;
+
   padding: 8px 20px;
-  border-radius: 6px;
+  border-radius: $radius-md;
   cursor: pointer;
   font-size: 0.85rem;
   font-weight: 600;
+  background: transparent;
+  border: 1px solid rgba($champion-gold, 0.5);
+  color: $champion-gold;
+  transition: background $transition-fast;
 
-  &:hover { background: rgba(240,192,64,0.1); }
+  &:hover {
+    background: rgba($champion-gold, 0.08);
+  }
 }
 
 // Empty state
 .ai-review-list__empty {
   text-align: center;
   padding: 48px 0;
-  color: var(--color-text-secondary, rgba(255, 255, 255, 0.6));
+  color: var(--xomper-text-secondary, #{$text-secondary});
   font-size: 0.9rem;
 }
 
@@ -106,8 +116,9 @@
 .spinner {
   width: 28px;
   height: 28px;
-  border: 3px solid rgba(255,255,255,0.15);
-  border-top-color: var(--color-champion-gold, #f0c040);
+  border: 3px solid rgba($surface-light, 0.4);
+  // s10: was #f0c040 (off-palette). Correct: championGold.
+  border-top-color: var(--xomper-champion-gold, #{$champion-gold});
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }
@@ -119,7 +130,7 @@
 // End-of-list label
 .ai-review-list__end {
   text-align: center;
-  color: var(--color-text-tertiary, rgba(255, 255, 255, 0.35));
+  color: var(--xomper-text-muted, #{$text-muted});
   font-size: 0.75rem;
   margin-top: 16px;
 }

--- a/src/app/pages/landing/cards/landing-announcements-card/landing-announcements-card.component.scss
+++ b/src/app/pages/landing/cards/landing-announcements-card/landing-announcements-card.component.scss
@@ -1,4 +1,5 @@
 @import 'styles/variables';
+@import 'styles/theme';
 
 .announcements-card {
   display: flex;
@@ -28,16 +29,17 @@
   gap: $spacing-sm;
 }
 
-// Individual row
+// Individual row — xomper-card base + accent bar
 .announcement-row {
+  @include xomper-card;
+
   display: flex;
-  border-radius: $radius-lg;
-  background: $card-gradient;
   overflow: hidden;
 
   &__accent {
     width: 3px;
-    background: #ef4444; // accentRed
+    // s10: was #ef4444 (off-palette). Correct: accentRed.
+    background: $accent-red;
     flex-shrink: 0;
   }
 
@@ -58,7 +60,8 @@
     font-size: 0.6rem;
     font-weight: 700;
     letter-spacing: 0.05em;
-    color: #ef4444;
+    // s10: was #ef4444 (off-palette). Correct: accentRed.
+    color: $accent-red;
     flex-shrink: 0;
   }
 

--- a/src/app/pages/landing/cards/landing-draft-countdown-card/landing-draft-countdown-card.component.scss
+++ b/src/app/pages/landing/cards/landing-draft-countdown-card/landing-draft-countdown-card.component.scss
@@ -1,19 +1,13 @@
 @import 'styles/variables';
+@import 'styles/theme';
 
 .draft-card {
+  @include xomper-hero-card;
+
   padding: $spacing-md;
-  border-radius: $radius-lg;
-  background: $card-gradient;
-  border: 1px solid rgba($champion-gold, 0.3);
   cursor: pointer;
-  transition: box-shadow $transition-base, transform $transition-base;
   width: 100%;
   box-sizing: border-box;
-
-  &:hover {
-    box-shadow: 0 0 0 1px rgba($champion-gold, 0.5);
-    transform: translateY(-1px);
-  }
 }
 
 .draft-card__header {

--- a/src/app/pages/landing/cards/landing-headline-card/landing-headline-card.component.scss
+++ b/src/app/pages/landing/cards/landing-headline-card/landing-headline-card.component.scss
@@ -1,33 +1,38 @@
 @import 'styles/variables';
+@import 'styles/theme';
 
 .headline-card {
+  @include xomper-hero-card;
+
   display: block;
   padding: $spacing-md;
-  border-radius: $radius-lg;
-  background: $card-gradient;
   width: 100%;
   box-sizing: border-box;
 
-  // Gold border — hero treatment (matches iOS)
-  border: 1px solid rgba($champion-gold, 0.4);
-
+  // Placeholder and skeleton states override the hero treatment
   &--placeholder {
-    border: 1px solid rgba($champion-gold, 0.25);
+    border-color: rgba($champion-gold, 0.25);
+    background: $card-gradient;
+
+    &:hover {
+      transform: none;
+      box-shadow: none;
+    }
   }
 
   &--skeleton {
-    border: 1px solid rgba($surface-light, 0.2);
+    border-color: rgba($surface-light, 0.2);
+    background: $card-gradient;
+
+    &:hover {
+      transform: none;
+      box-shadow: none;
+    }
   }
 
   &--populated {
     text-decoration: none;
     cursor: pointer;
-    transition: box-shadow $transition-base, transform $transition-base;
-
-    &:hover {
-      box-shadow: 0 0 0 1px rgba($champion-gold, 0.6);
-      transform: translateY(-1px);
-    }
   }
 }
 
@@ -41,14 +46,7 @@
 
 // Gold pill chip (matches iOS typeChip)
 .headline-card__type-chip {
-  background: $champion-gold;
-  color: $deep-navy;
-  font-size: 0.65rem;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  padding: 3px $spacing-sm;
-  border-radius: 999px;
-  font-family: $font-body;
+  @include xomper-chip;
 }
 
 .headline-card__period {

--- a/src/app/pages/landing/cards/landing-standings-scroll-card/landing-standings-scroll-card.component.scss
+++ b/src/app/pages/landing/cards/landing-standings-scroll-card/landing-standings-scroll-card.component.scss
@@ -1,4 +1,5 @@
 @import 'styles/variables';
+@import 'styles/theme';
 
 .standings-scroll {
   display: flex;
@@ -24,12 +25,12 @@
 
 // Empty / loading card
 .standings-scroll__empty-card {
+  @include xomper-card;
+
   display: flex;
   align-items: center;
   gap: $spacing-sm;
   padding: $spacing-md;
-  border-radius: $radius-lg;
-  background: $card-gradient;
 }
 
 .standings-scroll__empty-icon {
@@ -56,19 +57,19 @@
   }
 }
 
-// Team chip
+// Team chip — card treatment with gold active border
 .team-chip {
+  @include xomper-card;
+
   display: flex;
   align-items: center;
   gap: $spacing-sm;
   padding: $spacing-sm $spacing-md;
   min-width: 140px;
-  border-radius: $radius-lg;
-  background: $card-gradient;
   border: 1px solid transparent;
   cursor: pointer;
   flex-shrink: 0;
-  transition: border-color $transition-base;
+  transition: border-color $transition-base, box-shadow $transition-base;
   text-align: left;
 
   &--mine {

--- a/src/app/pages/landing/cards/landing-this-week-card/landing-this-week-card.component.scss
+++ b/src/app/pages/landing/cards/landing-this-week-card/landing-this-week-card.component.scss
@@ -1,4 +1,5 @@
 @import 'styles/variables';
+@import 'styles/theme';
 
 .matchups-card {
   display: flex;
@@ -24,12 +25,12 @@
 
 // Empty / loading states
 .matchups-card__empty {
+  @include xomper-card;
+
   display: flex;
   align-items: center;
   gap: $spacing-sm;
   padding: $spacing-md;
-  border-radius: $radius-lg;
-  background: $card-gradient;
 }
 
 .matchups-card__empty-icon {
@@ -50,13 +51,14 @@
 }
 
 .matchup-row {
+  @include xomper-card;
+
   display: flex;
   align-items: center;
   gap: $spacing-sm;
   padding: $spacing-md;
-  border-radius: $radius-lg;
-  background: $card-gradient;
   border: 1px solid transparent;
+  transition: border-color $transition-base;
 
   &--mine {
     border-color: rgba($champion-gold, 0.4);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,17 +1,45 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 // ================================================
-// CSS Custom Property Tokens — Midnight Emerald
-// Consumed by shell components (s1+); do not remove until after s10.
+// CSS Custom Property Tokens — Midnight Emerald (full XomperColors palette)
+// Hexes sourced from XomperColors.swift — do not hand-edit hex values.
+// s10: extended from 6 → 25 tokens; keep --xomper-* namespace throughout.
 // ================================================
 :root {
+  // -- Backgrounds --
+  --xomper-deep-navy: #{$deep-navy};
+  --xomper-dark-navy: #{$dark-navy};
   --xomper-bg-dark: #{$bg-dark};
-  --xomper-champion-gold: #{$champion-gold};
-  --xomper-accent-red: #{$accent-red};
-  --xomper-text-primary: #{$text-primary};
   --xomper-bg-card: #{$bg-card};
+  --xomper-bg-card-hover: #{$bg-card-hover};
+  --xomper-bg-input: #{$bg-input};
+
+  // -- Accents --
+  --xomper-champion-gold: #{$champion-gold};
+  --xomper-steel-blue: #{$steel-blue};
+  --xomper-accent-red: #{$accent-red};
+
+  // -- Text --
+  --xomper-text-primary: #{$text-primary};
+  --xomper-text-secondary: #{$text-secondary};
   --xomper-text-muted: #{$text-muted};
+
+  // -- Semantic --
+  --xomper-success-green: #{$success-green};
+  --xomper-error-red: #{$error-red};
+  --xomper-surface-light: #{$surface-light};
+
+  // -- Legacy (migration only) --
+  --xomper-legacy-red: #{$legacy-red};
+  --xomper-legacy-blue: #{$legacy-blue};
+
+  // -- Gradients --
+  --xomper-bg-gradient: #{$bg-gradient};
+  --xomper-card-gradient: #{$card-gradient};
+  --xomper-gold-accent: #{$gold-accent};
+  --xomper-red-accent: #{$red-accent};
 }
 
 *,

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -1,0 +1,124 @@
+// ================================================
+// XOMPER Theme Mixins — Midnight Emerald accent treatment
+// s10: shared accent mixins consumed by all surfaces.
+// Import convention: @import 'styles/theme' in component SCSS.
+// All values map 1:1 to XomperColors.swift + XomperTheme.swift.
+// ================================================
+
+@import 'variables';
+
+// ------------------------------------------------------------------
+// xomper-gradient-bg
+// The full-page Midnight Emerald gradient background.
+// Maps to XomperColors.bgGradient (deepNavy → darkNavy → deepNavy, 180°).
+// ------------------------------------------------------------------
+@mixin xomper-gradient-bg {
+  background: $bg-gradient;
+  min-height: 100vh;
+}
+
+// ------------------------------------------------------------------
+// xomper-card
+// Standard surface card. Maps to XomperColors.bgCard + radius-lg + shadow-md.
+// ------------------------------------------------------------------
+@mixin xomper-card {
+  background: $bg-card;
+  border-radius: $radius-lg;
+  box-shadow: $shadow-md;
+}
+
+// ------------------------------------------------------------------
+// xomper-hero-card
+// Gold-bordered hero card over the card gradient, with hover lift.
+// Maps to iOS gold-border + cardGradient treatment (Landing headline,
+// AI Review header, Team Analyzer top cards).
+// ------------------------------------------------------------------
+@mixin xomper-hero-card {
+  background: $card-gradient;
+  border: 1px solid rgba($champion-gold, 0.4);
+  border-radius: $radius-lg;
+  box-shadow: $shadow-md;
+  transition: box-shadow $transition-base, transform $transition-base;
+
+  &:hover {
+    box-shadow: 0 0 0 1px rgba($champion-gold, 0.6), $shadow-lg;
+    transform: translateY(-1px);
+  }
+}
+
+// ------------------------------------------------------------------
+// xomper-section-divider
+// Red 3px top-bar + uppercase tracked red h2 text.
+// Maps to iOS Rectangle.fill(errorRed) + Text.uppercased().tracking(2).
+// Usage: apply to the wrapper element containing .section-bar + h2.
+// ------------------------------------------------------------------
+@mixin xomper-section-divider {
+  .section-bar {
+    height: 3px;
+    background: $accent-red;
+    width: 100%;
+    border-radius: 1px;
+    margin-bottom: 0;
+  }
+
+  h2,
+  .section-title {
+    color: $accent-red;
+    font-size: 1.05rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    margin: 12px 0 0;
+    line-height: 1.2;
+  }
+}
+
+// ------------------------------------------------------------------
+// xomper-subheader
+// Champion-gold h3 subheader.
+// Maps to iOS championGold foreground on h3 / subsection labels.
+// ------------------------------------------------------------------
+@mixin xomper-subheader {
+  color: $champion-gold;
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin: 14px 0 4px;
+  line-height: 1.3;
+}
+
+// ------------------------------------------------------------------
+// xomper-chip
+// Gold pill chip — solid. Maps to iOS typeChip (championGold bg, deepNavy text).
+// ------------------------------------------------------------------
+@mixin xomper-chip {
+  display: inline-flex;
+  align-items: center;
+  background: $champion-gold;
+  color: $deep-navy;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 3px $spacing-sm;
+  border-radius: 999px;
+  font-family: $font-body;
+  white-space: nowrap;
+}
+
+// ------------------------------------------------------------------
+// xomper-chip-outline
+// Gold outline chip — transparent bg. Used for secondary/filter chips.
+// ------------------------------------------------------------------
+@mixin xomper-chip-outline {
+  display: inline-flex;
+  align-items: center;
+  background: transparent;
+  color: $champion-gold;
+  border: 1px solid rgba($champion-gold, 0.5);
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 3px $spacing-sm;
+  border-radius: 999px;
+  font-family: $font-body;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary

PR 1 of 2 for s10 — the final web-iOS parity stub. Pure visual sweep; zero behavioral/logic changes. No `.ts` or `.html` files touched.

**What's in this PR:**

- Extended `src/styles.scss` `:root` from 6 → 25 CSS custom properties covering the full `XomperColors` palette, hexes verified against `XomperColors.swift`
- Created `src/styles/_theme.scss` with 7 shared accent mixins (see Mixin API below)
- Fixed `StyledMarkdownComponent` off-palette fallback hexes (real bug — see below)
- Swept B1 Shell/Sidebar and B2 Landing and B5 AI Review — the already-mostly-themed surfaces that exercise the mixin API

## Mixin API (locked)

| Mixin | Params | Purpose |
|---|---|---|
| `xomper-gradient-bg` | none | deepNavy → darkNavy → deepNavy 180° page background |
| `xomper-card` | none | bg-card + radius-lg + shadow-md |
| `xomper-hero-card` | none | card-gradient + gold border (rgba 0.4) + hover lift |
| `xomper-section-divider` | none | red 3px `.section-bar` + uppercase red h2/`.section-title` |
| `xomper-subheader` | none | champion-gold h3 / subsection label |
| `xomper-chip` | none | gold solid pill (champion-gold bg, deep-navy text) |
| `xomper-chip-outline` | none | gold outline pill (transparent bg) |

## StyledMarkdown hex fix (bug)

| Location | Was | Now |
|---|---|---|
| `.md-h2-bar`, `.md-h2` background/color | `#e53935` (off-palette) | `--xomper-accent-red` / `#FF4757` |
| `.md-h3`, `.md-quote__bar` color | `#f0c040` (off-palette) | `--xomper-champion-gold` / `#00FFAB` |
| All `--color-*` references | stale namespace | migrated to `--xomper-*` |

## Surfaces swept (PR 1)

- **B0 Foundation**: `styles.scss`, `_theme.scss` (new), `styled-markdown`
- **B1 Shell**: `shell-layout` (gradient bg), `sidebar` (gold left-bar active indicator), `mobile-drawer` (deep-navy scrim + panel shadow)
- **B2 Landing**: `landing-headline-card` → `xomper-hero-card`; `landing-draft-countdown-card` → `xomper-hero-card`; `landing-announcements-card` (#ef4444 → `$accent-red`, `xomper-card` rows); `landing-standings-scroll-card` + `landing-this-week-card` → `xomper-card`
- **B5 AI Review**: `ai-review-list` (tokens + shimmer), `ai-review-detail` (hero header card, body card), `ai-report-card-row` (xomper-card + token migration)

## Build

`npm run build` — clean compile, zero SCSS errors. Pre-existing bundle size budget warning (not introduced here).

## PR 2 queue

B3 League sub-pages, B4 Draft tabs, B6 Admin (heaviest), B7 Team Analyzer, B8 misc (~50 SCSS files).

References #100