### PR TITLE
s10 PR2: Midnight Emerald per-feature sweep (B3–B8)

### DIFF
--- a/docs/features/web-ios-parity/s10-midnight-emerald-sweep/EXECUTION_LOG.md
+++ b/docs/features/web-ios-parity/s10-midnight-emerald-sweep/EXECUTION_LOG.md
@@ -78,7 +78,7 @@ Both also referencing old `--color-*` namespace instead of `--xomper-*`. Updated
 
 ## Build
 
-`npm run build` — result: TBD
+`npm run build` — result: SUCCESS. Zero SCSS errors. Bundle size warning pre-existing (997 kB vs 512 kB budget) — not introduced by this PR.
 
 ---
 
@@ -89,3 +89,66 @@ Both also referencing old `--color-*` namespace instead of `--xomper-*`. Updated
 - B6: Admin portal (~18 sub-screens) — heaviest batch
 - B7: Team Analyzer (hexagon-chart, position-breakdown-card, recommended-trade-card)
 - B8: Misc (search, team, profile, settings, taxi-squad, matchup-history, link-sleeper, login, home, modals, toast, loader, confirm-dialog)
+
+---
+
+## PR 2 — Midnight Emerald per-feature sweep
+
+**Date**: 2026-06-06
+**Branch**: `feature/102-midnight-emerald-sweep`
+**Issue**: #102
+**Executor**: Pixel
+
+### B3 — League sub-pages (10 files)
+
+- `league/league.component.scss` — `xomper-hero-card` on `.league-container`
+- `league/standings/standings.component.scss` — `xomper-chip-outline` on `.view-button`; `.team-more-btn` → `$champion-gold`; silver/bronze → palette
+- `league/rules/scoring/scoring.component.scss` — `xomper-card` on `.scoring-category`; `xomper-subheader` on titles
+- `league/rules/league-settings/league-settings.component.scss` — `xomper-card` on `.setting-card`
+- `league/rules/payouts/payouts.component.scss` — theme import + subheader
+- `league/rules/rulebook/rulebook.component.scss` — `xomper-card` on `.rulebook-chapter`
+- `league/draft-order/draft-order.component.scss` — full rewrite from `var(--color-*)` namespace; `xomper-card` on cards/badges; `$champion-gold` accent
+- `league/matchups/matchups.component.scss` — `xomper-card` on `.week-section`/`.empty-state`; `xomper-chip-outline` on `.season-btn`
+
+### B4 — Draft tabs (5 files)
+
+- `draft-history/draft-history.component.scss` — `.year-btn.active` `$gold-accent` → `$champion-gold`
+- `draft-history/live/draft-live.component.scss` — `.chip.active` / `.pick-slot .pick-made` `$gold-accent` → `$champion-gold`
+- `draft-history/mocks/draft-mocks.component.scss` — theme import
+- `draft-history/picks/draft-picks.component.scss` — `.pick-number` bg `$gold-accent` → `$champion-gold`
+- `draft-history/recap/draft-recap.component.scss` — theme import
+
+### B6 — Admin portal (17 files)
+
+Full migration from `var(--color-surface-elevated)` / `var(--color-*)` old namespace + hardcoded off-palette greens/reds to `$variables` + `xomper-card`/`xomper-chip-outline` mixins across all admin sub-screens. `$champion-gold` replaces `#10b981`/`#4caf50`/`#34d399`. `$error-red` replaces `#f87171`/`#e53935`. All button backgrounds using `rgba(255,255,255,0.1)` → `rgba($surface-light, 0.2)`.
+
+Files: `admin.component.scss`, `admin-ai-review.component.scss`, `admin-ai-review-preview.component.scss`, `admin-announcement-edit.component.scss`, `admin-announcements-list.component.scss`, `admin-audit-detail.component.scss`, `admin-audit-feed.component.scss`, `admin-cron-settings.component.scss`, `admin-email-archive-detail.component.scss`, `admin-email-archive-list.component.scss`, `admin-logs.component.scss`, `admin-tables-menu.component.scss`, `admin-league-edit.component.scss`, `admin-tables-leagues.component.scss`, `admin-user-edit.component.scss`, `admin-tables-users.component.scss`, `admin-test-email.component.scss`
+
+### B7 — Team Analyzer (4 files)
+
+Converted all 4 files from `@use '...variables' as v` to `@import` to resolve `_theme.scss` `@import`/`@use` mix conflict. Applied `xomper-card` on breakdown/eval/avg/side cards; `xomper-hero-card` on `.balance-card`; `xomper-chip` on `.you-badge`.
+
+### B8 — Misc (13 files)
+
+- `login/login.component.scss` — `xomper-hero-card` on `.login-box`; `#ef4444` → `$error-red`
+- `search/search.component.scss` — `xomper-card` on `.search-box`; `.mode-btn.active` / `.search-btn` `$gold-accent` → `$champion-gold`
+- `profile/profile.component.scss` — `xomper-card` on `.profile-container` and `.league-card`; `.league-more-btn` `$steel-blue` → `$champion-gold`
+- `team/team.component.scss` — `xomper-card` on `.team-header`; `.user-name`/`.clickable` `$steel-blue` → `$text-secondary`/`$champion-gold` hover
+- `settings/settings.component.scss` — migrate `var(--xomper-*)` → `$variables`; `xomper-card` on `.settings-card`
+- `taxi-squad/taxi-squad.component.scss` — `$gold-accent` → `$champion-gold` on tab `.active`; `.clickable` `$steel-blue` → `$text-secondary`
+- `matchup-history/matchup-history.component.scss` — `xomper-card` on `.empty-state` and `.week-section`
+- `link-sleeper/link-sleeper.component.scss` — `xomper-hero-card` on `.link-card`; `.search-btn`/`.confirm-btn.yes` `$gold-accent` → `$champion-gold`
+- `confirm-dialog/confirm-dialog.component.scss` — full rewrite from `var(--color-*)` namespace; `xomper-card` on `.dialog-box`; `.btn-confirm` → `$champion-gold`; `.btn-confirm.destructive` → `$error-red`
+- `matchup-modal/matchup-modal.component.scss` — `xomper-card` on `.matchup-modal`
+- `player-modal/player-modal.component.scss` — `xomper-hero-card` on `.modal-card`
+- `taxi-squad-player-modal/taxi-squad-player-modal.component.scss` — `xomper-hero-card` on `.modal-card`; `.steal-btn` `$gold-accent` → `$champion-gold`
+- `loader/loader.component.scss`, `toast/toast.component.scss` — theme import added (already clean)
+
+### Build
+
+`npm run build` — PASS. Zero SCSS errors. Bundle size warning is pre-existing.
+
+### Files skipped
+
+- `home/home.component.scss` — thin host selector only, nothing to theme
+- Playoffs/world-cup/rule-proposals — already tokenized or structural-only SCSS with no card/color deltas

--- a/docs/features/web-ios-parity/s10-midnight-emerald-sweep/PLAN.md
+++ b/docs/features/web-ios-parity/s10-midnight-emerald-sweep/PLAN.md
@@ -130,13 +130,13 @@ Large diff, **low risk** — pure presentation, no `.ts`/`.html` logic touched. 
 - [ ] **5 — Sweep B2 Landing** (replace ad-hoc gold-border with `xomper-hero-card`) → smoke test.
 - [ ] **6 — Sweep B5 AI Review** → smoke test.
 - [ ] **7 — Build PR 1, `/ultrareview`, open PR** (`Closes #<issue-part-1>` or single issue w/ checklist).
-- [ ] **8 — Sweep B3 League sub-pages** → smoke test each route.
-- [ ] **9 — Sweep B4 Draft tabs** → smoke test.
-- [ ] **10 — Sweep B6 Admin** (heaviest — replace raw greys with tokens, apply card/chip mixins) → smoke test each sub-screen.
-- [ ] **11 — Sweep B7 Team Analyzer** (gold hexagon stroke) → smoke test.
-- [ ] **12 — Sweep B8 Search + misc** (incl. modals, toast, loader) → smoke test.
-- [ ] **13 — Full build** (`ng build`) — confirm no SCSS compile errors, no unused-import warnings.
-- [ ] **14 — `/ultrareview`, open PR 2.**
+- [x] **8 — Sweep B3 League sub-pages** → smoke test each route.
+- [x] **9 — Sweep B4 Draft tabs** → smoke test.
+- [x] **10 — Sweep B6 Admin** (heaviest — replace raw greys with tokens, apply card/chip mixins) → smoke test each sub-screen.
+- [x] **11 — Sweep B7 Team Analyzer** (gold hexagon stroke) → smoke test.
+- [x] **12 — Sweep B8 Search + misc** (incl. modals, toast, loader) → smoke test.
+- [x] **13 — Full build** (`ng build`) — confirm no SCSS compile errors, no unused-import warnings.
+- [x] **14 — `/ultrareview`, open PR 2.**
 
 ---
 

--- a/src/app/components/confirm-dialog/confirm-dialog.component.scss
+++ b/src/app/components/confirm-dialog/confirm-dialog.component.scss
@@ -1,3 +1,7 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .dialog-overlay {
   position: fixed;
   inset: 0;
@@ -5,49 +9,48 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: $z-modal;
 }
 
 .dialog-box {
-  background: var(--color-surface-elevated, #1e2a1e);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 12px;
-  padding: 24px;
+  @include xomper-card;
+  padding: $spacing-lg;
   max-width: 400px;
   width: calc(100% - 48px);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: $spacing-md;
 }
 
 .dialog-title {
-  font-size: 1rem;
+  font-size: $text-base;
   font-weight: 600;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
   margin: 0;
 }
 
 .dialog-message {
-  font-size: 0.875rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-sm;
+  color: $text-secondary;
   margin: 0;
   line-height: 1.5;
 }
 
 .dialog-actions {
   display: flex;
-  gap: 12px;
+  gap: $spacing-sm;
   justify-content: flex-end;
 }
 
 button {
   padding: 8px 20px;
-  border-radius: 8px;
-  font-size: 0.875rem;
+  border-radius: $radius-md;
+  font-size: $text-sm;
   font-weight: 500;
+  font-family: $font-body;
   cursor: pointer;
   border: none;
-  transition: opacity 0.15s;
+  transition: opacity $transition-fast;
 
   &:hover {
     opacity: 0.85;
@@ -55,16 +58,17 @@ button {
 }
 
 .btn-cancel {
-  background: var(--color-surface, #132013);
-  color: var(--color-text-secondary, #a5c8a5);
-  border: 1px solid var(--color-border, #2d3f2d);
+  background: $bg-card;
+  color: $text-secondary;
+  border: 1px solid rgba($surface-light, 0.3);
 }
 
 .btn-confirm {
-  background: var(--color-success-green, #4caf50);
-  color: #fff;
+  background: $champion-gold;
+  color: $deep-navy;
 
   &.destructive {
-    background: var(--color-error-red, #e53935);
+    background: $error-red;
+    color: #fff;
   }
 }

--- a/src/app/components/loader/loader.component.scss
+++ b/src/app/components/loader/loader.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .loader {
   position: fixed;

--- a/src/app/components/matchup-modal/matchup-modal.component.scss
+++ b/src/app/components/matchup-modal/matchup-modal.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .modal-backdrop {
   position: fixed;
@@ -13,15 +14,12 @@
 }
 
 .matchup-modal {
+  @include xomper-card;
   position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: $card-gradient;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba($surface-light, 0.3);
   color: $text-primary;
-  border-radius: $radius-lg;
   width: 95%;
   max-width: 900px;
   max-height: 90vh;

--- a/src/app/components/player-modal/player-modal.component.scss
+++ b/src/app/components/player-modal/player-modal.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .modal-backdrop {
   position: fixed;
@@ -19,6 +20,7 @@
 }
 
 .modal-card {
+  @include xomper-hero-card;
   position: fixed;
   top: 50%;
   left: 50%;
@@ -28,10 +30,6 @@
   width: 90%;
   max-height: 90vh;
   overflow-y: auto;
-  background: $card-gradient;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba($champion-gold, 0.3);
-  border-radius: $radius-lg;
   padding: $spacing-xl;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   display: flex;

--- a/src/app/components/taxi-squad-player-modal/taxi-squad-player-modal.component.scss
+++ b/src/app/components/taxi-squad-player-modal/taxi-squad-player-modal.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .modal-backdrop {
   position: fixed;
@@ -19,6 +20,7 @@
 }
 
 .modal-card {
+  @include xomper-hero-card;
   position: fixed;
   top: 50%;
   left: 50%;
@@ -28,10 +30,6 @@
   width: 90%;
   max-height: 90vh;
   overflow-y: auto;
-  background: $card-gradient;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba($champion-gold, 0.3);
-  border-radius: $radius-lg;
   padding: $spacing-xl;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   display: flex;
@@ -179,7 +177,7 @@
   font-weight: 700;
   font-family: $font-body;
   color: $deep-navy;
-  background: $gold-accent;
+  background: $champion-gold;
   border: none;
   border-radius: $radius-xl;
   cursor: pointer;

--- a/src/app/components/toast/toast.component.scss
+++ b/src/app/components/toast/toast.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .toast {
   position: fixed;

--- a/src/app/pages/admin/admin.component.scss
+++ b/src/app/pages/admin/admin.component.scss
@@ -1,48 +1,52 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .admin-shell {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 800px;
   margin: 0 auto;
 }
 
 .admin-header {
-  margin-bottom: 32px;
+  margin-bottom: $spacing-xl;
 }
 
 .admin-title {
+  font-family: $font-display;
   font-size: 1.75rem;
   font-weight: 700;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
   margin: 0 0 4px;
 }
 
 .admin-subtitle {
-  font-size: 0.875rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-sm;
+  color: $text-secondary;
   margin: 0;
 }
 
 .tile-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 16px;
+  gap: $spacing-md;
 }
 
 .tile {
+  @include xomper-card;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 8px;
-  padding: 20px 16px;
-  background: var(--color-surface-elevated, #1e2a1e);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 12px;
+  gap: $spacing-sm;
+  padding: 20px $spacing-md;
   cursor: pointer;
   text-align: left;
-  transition: background 0.15s, border-color 0.15s;
+  transition: background $transition-fast, border-color $transition-fast;
+  border: 1px solid rgba($surface-light, 0.3);
 
   &:hover:not(.disabled) {
-    background: var(--color-surface-hover, #243624);
-    border-color: var(--color-success-green, #4caf50);
+    background: $bg-card-hover;
+    border-color: $champion-gold;
   }
 
   &.disabled {
@@ -59,12 +63,12 @@
 .tile-label {
   font-size: 0.9375rem;
   font-weight: 600;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
   line-height: 1.2;
 }
 
 .tile-subtitle {
-  font-size: 0.75rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-xs;
+  color: $text-secondary;
   line-height: 1.4;
 }

--- a/src/app/pages/admin/ai-review/admin-ai-review.component.scss
+++ b/src/app/pages/admin/ai-review/admin-ai-review.component.scss
@@ -1,23 +1,28 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .ai-review-admin {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 900px;
   margin: 0 auto;
 }
 
 .page-header {
-  margin-bottom: 32px;
+  margin-bottom: $spacing-xl;
 }
 
 .page-title {
+  font-family: $font-display;
   font-size: 1.5rem;
   font-weight: 700;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
   margin: 0 0 4px;
 }
 
 .page-subtitle {
-  font-size: 0.875rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-sm;
+  color: $text-secondary;
   margin: 0;
 }
 
@@ -26,12 +31,12 @@
 }
 
 .section-title {
-  font-size: 1rem;
+  font-size: $text-sm;
   font-weight: 600;
-  color: var(--color-text-secondary, #a5c8a5);
+  color: $text-secondary;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  margin: 0 0 16px;
+  margin: 0 0 $spacing-md;
 }
 
 .section-header-row {
@@ -40,23 +45,22 @@
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 12px;
-  margin-bottom: 16px;
+  margin-bottom: $spacing-md;
 }
 
 .card-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 16px;
+  gap: $spacing-md;
 }
 
 .trigger-card {
-  background: var(--color-surface-elevated, #1e2a1e);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 12px;
+  @include xomper-card;
   padding: 20px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: $spacing-md;
+  border: 1px solid rgba($surface-light, 0.3);
 }
 
 .card-header {
@@ -68,12 +72,12 @@
 .card-label {
   font-size: 0.9375rem;
   font-weight: 600;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
 }
 
 .card-desc {
-  font-size: 0.75rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-xs;
+  color: $text-secondary;
 }
 
 .card-form {
@@ -87,11 +91,11 @@
   justify-content: space-between;
   align-items: center;
   font-size: 0.8125rem;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
   cursor: pointer;
 
   input[type="checkbox"] {
-    accent-color: var(--color-success-green, #4caf50);
+    accent-color: $champion-gold;
     width: 16px;
     height: 16px;
   }
@@ -103,22 +107,27 @@
   gap: 4px;
 
   label {
-    font-size: 0.75rem;
-    color: var(--color-text-secondary, #a5c8a5);
+    font-size: $text-xs;
+    color: $text-secondary;
   }
 
   input {
-    background: var(--color-surface, #132013);
-    border: 1px solid var(--color-border, #2d3f2d);
-    border-radius: 6px;
-    color: var(--color-text-primary, #e8f5e9);
-    font-size: 0.875rem;
+    background: $bg-input;
+    border: 1px solid rgba($surface-light, 0.4);
+    border-radius: $radius-md;
+    color: $text-primary;
+    font-size: $text-sm;
     padding: 6px 10px;
     width: 100%;
     box-sizing: border-box;
 
     &::placeholder {
-      color: var(--color-text-muted, #6b8c6b);
+      color: $text-muted;
+    }
+
+    &:focus {
+      outline: none;
+      border-color: $champion-gold;
     }
   }
 }
@@ -126,24 +135,28 @@
 .card-footer {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: $spacing-sm;
 }
 
 .btn-run {
-  background: var(--color-success-green, #4caf50);
-  color: #fff;
+  background: $champion-gold;
+  color: $deep-navy;
   border: none;
-  border-radius: 8px;
-  padding: 8px 16px;
-  font-size: 0.875rem;
-  font-weight: 500;
+  border-radius: $radius-md;
+  padding: 8px $spacing-md;
+  font-size: $text-sm;
+  font-weight: 600;
   cursor: pointer;
   width: 100%;
-  transition: opacity 0.15s;
+  transition: filter $transition-fast;
 
   &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  &:hover:not(:disabled) {
+    filter: brightness(1.1);
   }
 }
 
@@ -155,36 +168,37 @@
 }
 
 .result-badge {
-  font-size: 0.75rem;
+  font-size: $text-xs;
   font-weight: 600;
-  padding: 2px 8px;
-  border-radius: 4px;
+  padding: 2px $spacing-sm;
+  border-radius: $radius-sm;
 
-  &.success { background: rgba(76, 175, 80, 0.2); color: #4caf50; }
-  &.error { background: rgba(229, 57, 53, 0.2); color: #e53935; }
+  &.success { background: rgba($success-green, 0.2); color: $success-green; }
+  &.error { background: rgba($error-red, 0.2); color: $error-red; }
 }
 
 .result-dry {
-  font-size: 0.75rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-xs;
+  color: $text-secondary;
 }
 
 .btn-preview {
   background: none;
-  border: 1px solid var(--color-champion-gold, #ffc107);
-  color: var(--color-champion-gold, #ffc107);
-  border-radius: 6px;
+  border: 1px solid rgba($champion-gold, 0.5);
+  color: $champion-gold;
+  border-radius: $radius-md;
   padding: 4px 10px;
-  font-size: 0.75rem;
+  font-size: $text-xs;
   cursor: pointer;
   white-space: nowrap;
+  transition: background $transition-fast;
 
-  &:hover { background: rgba(255, 193, 7, 0.1); }
+  &:hover { background: rgba($champion-gold, 0.1); }
 }
 
 .result-msg {
-  font-size: 0.75rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-xs;
+  color: $text-secondary;
   margin: 0;
   width: 100%;
 }
@@ -192,7 +206,7 @@
 /* Activity feed */
 .filter-row {
   display: flex;
-  gap: 8px;
+  gap: $spacing-sm;
   flex-wrap: wrap;
 }
 
@@ -202,31 +216,32 @@
 }
 
 .filter-btn {
-  background: var(--color-surface, #132013);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 6px;
-  color: var(--color-text-secondary, #a5c8a5);
-  font-size: 0.75rem;
+  background: $bg-card;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  color: $text-secondary;
+  font-size: $text-xs;
   padding: 4px 10px;
   cursor: pointer;
   text-transform: capitalize;
+  transition: all $transition-fast;
 
   &.active {
-    background: var(--color-success-green, #4caf50);
-    border-color: var(--color-success-green, #4caf50);
-    color: #fff;
+    background: $champion-gold;
+    border-color: $champion-gold;
+    color: $deep-navy;
   }
 }
 
 .loading-state,
 .error-state,
 .feed-empty {
-  font-size: 0.875rem;
-  color: var(--color-text-secondary, #a5c8a5);
-  padding: 16px 0;
+  font-size: $text-sm;
+  color: $text-secondary;
+  padding: $spacing-md 0;
 }
 
-.error-state { color: var(--color-error-red, #e53935); }
+.error-state { color: $error-red; }
 
 .feed-list {
   list-style: none;
@@ -234,59 +249,58 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: $spacing-sm;
 }
 
 .feed-entry {
   display: flex;
   align-items: center;
   gap: 10px;
-  background: var(--color-surface-elevated, #1e2a1e);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 8px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.2);
   padding: 10px 14px;
   font-size: 0.8125rem;
   flex-wrap: wrap;
 }
 
 .entry-kind {
-  font-size: 0.7rem;
+  font-size: $text-xs;
   font-weight: 600;
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: $radius-sm;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 
-  &.push { background: rgba(100, 181, 246, 0.15); color: #64b5f6; }
-  &.email { background: rgba(255, 193, 7, 0.15); color: #ffc107; }
+  &.push { background: rgba($steel-blue, 0.15); color: $steel-blue; }
+  &.email { background: rgba($champion-gold, 0.15); color: $champion-gold; }
 }
 
 .entry-status {
-  font-size: 0.7rem;
+  font-size: $text-xs;
   font-weight: 600;
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: $radius-sm;
 
-  &.ok { background: rgba(76, 175, 80, 0.15); color: #4caf50; }
-  &.fail { background: rgba(229, 57, 53, 0.15); color: #e53935; }
+  &.ok { background: rgba($success-green, 0.15); color: $success-green; }
+  &.fail { background: rgba($error-red, 0.15); color: $error-red; }
 }
 
 .entry-label {
   flex: 1;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .entry-time {
-  color: var(--color-text-secondary, #a5c8a5);
-  font-size: 0.75rem;
+  color: $text-secondary;
+  font-size: $text-xs;
   white-space: nowrap;
 }
 
 .entry-error {
   width: 100%;
-  font-size: 0.75rem;
-  color: var(--color-error-red, #e53935);
+  font-size: $text-xs;
+  color: $error-red;
 }

--- a/src/app/pages/admin/ai-review/preview/admin-ai-review-preview.component.scss
+++ b/src/app/pages/admin/ai-review/preview/admin-ai-review-preview.component.scss
@@ -1,40 +1,45 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .preview-screen {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 800px;
   margin: 0 auto;
 }
 
 .back-row {
-  margin-bottom: 16px;
+  margin-bottom: $spacing-md;
 }
 
 .btn-back {
   background: none;
   border: none;
-  color: var(--color-success-green, #4caf50);
-  font-size: 0.875rem;
+  color: $champion-gold;
+  font-size: $text-sm;
   cursor: pointer;
   padding: 0;
+  transition: opacity $transition-fast;
 
   &:hover { opacity: 0.8; }
 }
 
-.page-header { margin-bottom: 24px; }
+.page-header { margin-bottom: $spacing-lg; }
 
 .page-title {
+  font-family: $font-display;
   font-size: 1.5rem;
   font-weight: 700;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
   margin: 0;
   text-transform: capitalize;
 }
 
 .report-card {
-  background: var(--color-surface-elevated, #1e2a1e);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 12px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.2);
   padding: 20px;
-  margin-bottom: 24px;
+  margin-bottom: $spacing-lg;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -43,19 +48,19 @@
 .report-meta {
   display: flex;
   justify-content: space-between;
-  font-size: 0.875rem;
+  font-size: $text-sm;
 }
 
-.meta-label { color: var(--color-text-secondary, #a5c8a5); }
-.meta-value { color: var(--color-text-primary, #e8f5e9); font-weight: 500; }
+.meta-label { color: $text-secondary; }
+.meta-value { color: $text-primary; font-weight: 500; }
 
 .dnb-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 12px 0;
-  border-top: 1px solid var(--color-border, #2d3f2d);
-  border-bottom: 1px solid var(--color-border, #2d3f2d);
+  border-top: 1px solid rgba($surface-light, 0.3);
+  border-bottom: 1px solid rgba($surface-light, 0.3);
 }
 
 .dnb-info {
@@ -65,56 +70,58 @@
 }
 
 .dnb-label {
-  font-size: 0.875rem;
+  font-size: $text-sm;
   font-weight: 600;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
 }
 
 .dnb-hint {
-  font-size: 0.75rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-xs;
+  color: $text-secondary;
 }
 
 .dnb-toggle {
-  background: var(--color-surface, #132013);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 6px;
-  color: var(--color-text-secondary, #a5c8a5);
-  font-size: 0.75rem;
+  background: $bg-input;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  color: $text-secondary;
+  font-size: $text-xs;
   font-weight: 600;
   padding: 6px 14px;
   cursor: pointer;
   min-width: 52px;
+  transition: all $transition-fast;
 
   &.active {
-    background: rgba(229, 57, 53, 0.15);
-    border-color: var(--color-error-red, #e53935);
-    color: var(--color-error-red, #e53935);
+    background: rgba($error-red, 0.15);
+    border-color: $error-red;
+    color: $error-red;
   }
 
   &:disabled { opacity: 0.5; cursor: not-allowed; }
 }
 
 .btn-broadcast {
-  background: var(--color-champion-gold, #ffc107);
-  color: #000;
+  background: $champion-gold;
+  color: $deep-navy;
   border: none;
-  border-radius: 8px;
+  border-radius: $radius-md;
   padding: 10px;
-  font-size: 0.875rem;
+  font-size: $text-sm;
   font-weight: 600;
   cursor: pointer;
-  transition: opacity 0.15s;
+  transition: filter $transition-fast;
 
   &:disabled { opacity: 0.4; cursor: not-allowed; }
+  &:hover:not(:disabled) { filter: brightness(1.1); }
 }
 
-.section { margin-bottom: 24px; }
+.section { margin-bottom: $spacing-lg; }
 
 .section-title {
-  font-size: 0.875rem;
+  font-size: $text-sm;
   font-weight: 600;
-  color: var(--color-text-secondary, #a5c8a5);
+  color: $text-secondary;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   margin: 0 0 12px;
@@ -126,20 +133,20 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: $spacing-sm;
 }
 
 .recipient-row {
   display: flex;
   align-items: center;
   gap: 12px;
-  background: var(--color-surface-elevated, #1e2a1e);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 8px;
-  padding: 12px 16px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.2);
+  padding: 12px $spacing-md;
   cursor: pointer;
+  transition: border-color $transition-fast;
 
-  &:hover { border-color: var(--color-success-green, #4caf50); }
+  &:hover { border-color: $champion-gold; }
 }
 
 .recipient-info {
@@ -150,37 +157,37 @@
 }
 
 .recipient-name {
-  font-size: 0.875rem;
+  font-size: $text-sm;
   font-weight: 600;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
 }
 
 .recipient-email {
-  font-size: 0.75rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-xs;
+  color: $text-secondary;
 }
 
 .recipient-subject {
   flex: 1;
   font-size: 0.8125rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  color: $text-secondary;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .chevron {
-  color: var(--color-text-secondary, #a5c8a5);
+  color: $text-secondary;
   font-size: 1.25rem;
 }
 
 .empty-state, .loading-state, .error-state {
-  font-size: 0.875rem;
-  color: var(--color-text-secondary, #a5c8a5);
-  padding: 16px 0;
+  font-size: $text-sm;
+  color: $text-secondary;
+  padding: $spacing-md 0;
 }
 
-.error-state { color: var(--color-error-red, #e53935); }
+.error-state { color: $error-red; }
 
 /* Modal */
 .modal-overlay {
@@ -191,21 +198,20 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px;
+  padding: $spacing-lg;
 }
 
 .modal-box {
-  background: var(--color-surface-elevated, #1e2a1e);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 12px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.3);
   width: 100%;
   max-width: 640px;
   max-height: 80vh;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 24px;
+  gap: $spacing-md;
+  padding: $spacing-lg;
 }
 
 .modal-header {
@@ -215,37 +221,40 @@
 }
 
 .modal-name {
-  font-size: 1rem;
+  font-size: $text-base;
   font-weight: 600;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
 }
 
 .modal-email {
-  font-size: 0.75rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-xs;
+  color: $text-secondary;
 }
 
 .modal-close {
   background: none;
   border: none;
-  color: var(--color-text-secondary, #a5c8a5);
+  color: $text-secondary;
   font-size: 1.25rem;
   cursor: pointer;
   padding: 0;
   line-height: 1;
+  transition: color $transition-fast;
+
+  &:hover { color: $text-primary; }
 }
 
 .modal-subject {
-  font-size: 0.875rem;
+  font-size: $text-sm;
   font-weight: 600;
-  color: var(--color-text-primary, #e8f5e9);
-  border-top: 1px solid var(--color-border, #2d3f2d);
+  color: $text-primary;
+  border-top: 1px solid rgba($surface-light, 0.3);
   padding-top: 12px;
 }
 
 .modal-body {
-  font-size: 0.875rem;
-  color: var(--color-text-primary, #e8f5e9);
+  font-size: $text-sm;
+  color: $text-primary;
   line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;

--- a/src/app/pages/admin/announcements/edit/admin-announcement-edit.component.scss
+++ b/src/app/pages/admin/announcements/edit/admin-announcement-edit.component.scss
@@ -1,5 +1,9 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .announcement-edit {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 600px;
   margin: 0 auto;
 }
@@ -7,20 +11,21 @@
 .edit-header {
   display: flex;
   align-items: center;
-  gap: 16px;
-  margin-bottom: 32px;
+  gap: $spacing-md;
+  margin-bottom: $spacing-xl;
 
   h2 {
     margin: 0;
     font-size: 1.4rem;
     font-weight: 600;
+    color: $text-primary;
   }
 }
 
 .btn-back {
   background: none;
   border: none;
-  color: #10b981;
+  color: $champion-gold;
   cursor: pointer;
   font-size: 0.95rem;
   padding: 0;
@@ -48,15 +53,15 @@
   }
 
   label {
-    font-size: 0.875rem;
+    font-size: $text-sm;
     font-weight: 500;
-    color: rgba(255, 255, 255, 0.7);
+    color: $text-secondary;
   }
 }
 
 .field-hint {
-  font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.4);
+  font-size: $text-xs;
+  color: $text-muted;
   margin: 0;
 }
 
@@ -64,26 +69,28 @@ input[type="text"],
 input[type="number"],
 input[type="datetime-local"],
 textarea {
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 8px;
-  color: #fff;
-  font-size: 0.9rem;
+  background: $bg-input;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  color: $text-primary;
+  font-size: $text-sm;
   padding: 10px 12px;
   outline: none;
   resize: vertical;
+  font-family: $font-body;
 
   &:focus {
-    border-color: #10b981;
+    border-color: $champion-gold;
   }
 
-  &::placeholder { color: rgba(255, 255, 255, 0.3); }
+  &::placeholder { color: $text-muted; }
 }
 
 input[type="checkbox"] {
   width: 18px;
   height: 18px;
   cursor: pointer;
+  accent-color: $champion-gold;
 }
 
 .radio-group {
@@ -94,71 +101,76 @@ input[type="checkbox"] {
 .radio-label {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 0.9rem;
+  gap: $spacing-sm;
+  font-size: $text-sm;
   cursor: pointer;
+  color: $text-secondary;
 
   input[type="radio"] { width: 16px; height: 16px; cursor: pointer; }
 }
 
 .field-error {
-  font-size: 0.75rem;
-  color: #f87171;
+  font-size: $text-xs;
+  color: $error-red;
   margin: 0;
 }
 
-.feedback-error   { color: #f87171; font-size: 0.875rem; margin: 0; }
-.feedback-success { color: #34d399; font-size: 0.875rem; margin: 0; }
+.feedback-error   { color: $error-red; font-size: $text-sm; margin: 0; }
+.feedback-success { color: $success-green; font-size: $text-sm; margin: 0; }
 
 .form-actions {
   display: flex;
   gap: 12px;
-  margin-top: 8px;
+  margin-top: $spacing-sm;
 
   .btn-secondary {
     flex: 1;
-    background: rgba(255, 255, 255, 0.1);
-    color: #fff;
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 8px;
+    background: rgba($surface-light, 0.2);
+    color: $text-primary;
+    border: 1px solid rgba($surface-light, 0.4);
+    border-radius: $radius-md;
     padding: 10px;
-    font-size: 0.9rem;
+    font-size: $text-sm;
+    font-family: $font-body;
     cursor: pointer;
+    transition: background $transition-fast;
 
-    &:hover { background: rgba(255, 255, 255, 0.15); }
+    &:hover { background: rgba($surface-light, 0.3); }
   }
 
   .btn-primary {
     flex: 2;
-    background: #10b981;
-    color: #000;
+    background: $champion-gold;
+    color: $deep-navy;
     border: none;
-    border-radius: 8px;
+    border-radius: $radius-md;
     padding: 10px;
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: 700;
+    font-family: $font-body;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 8px;
+    gap: $spacing-sm;
+    transition: filter $transition-fast;
 
     &:disabled { opacity: 0.5; cursor: not-allowed; }
-    &:hover:not(:disabled) { background: #059669; }
+    &:hover:not(:disabled) { filter: brightness(1.1); }
   }
 }
 
 .state-loading {
   padding: 48px 0;
   text-align: center;
-  color: rgba(255, 255, 255, 0.5);
+  color: $text-muted;
 }
 
 .spinner-sm {
   width: 16px;
   height: 16px;
-  border: 2px solid rgba(0, 0, 0, 0.3);
-  border-top-color: #000;
+  border: 2px solid rgba($deep-navy, 0.3);
+  border-top-color: $deep-navy;
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
   display: inline-block;

--- a/src/app/pages/admin/announcements/list/admin-announcements-list.component.scss
+++ b/src/app/pages/admin/announcements/list/admin-announcements-list.component.scss
@@ -1,5 +1,9 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .announcements-list {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 800px;
   margin: 0 auto;
 }
@@ -8,26 +12,28 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 24px;
+  margin-bottom: $spacing-lg;
 
   h2 {
     margin: 0;
+    font-family: $font-display;
     font-size: 1.5rem;
     font-weight: 600;
+    color: $text-primary;
   }
 }
 
 .state-empty {
   text-align: center;
-  padding: 48px 16px;
-  color: rgba(255, 255, 255, 0.5);
+  padding: 48px $spacing-md;
+  color: $text-muted;
 
-  &.state-warning { color: #f59e0b; }
-  &.state-error   { color: #ef4444; }
+  &.state-warning { color: $champion-gold; }
+  &.state-error   { color: $error-red; }
 
-  .state-title { font-weight: 600; margin-bottom: 8px; }
-  .state-body  { font-size: 0.875rem; }
-  .state-sub   { font-size: 0.875rem; margin-top: 4px; }
+  .state-title { font-weight: 600; margin-bottom: $spacing-sm; }
+  .state-body  { font-size: $text-sm; }
+  .state-sub   { font-size: $text-sm; margin-top: 4px; }
 }
 
 .row-list {
@@ -43,9 +49,9 @@
   display: flex;
   align-items: flex-start;
   gap: 12px;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 12px;
-  padding: 16px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.2);
+  padding: $spacing-md;
 }
 
 .row-body {
@@ -62,31 +68,30 @@
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  margin-bottom: 8px;
+  margin-bottom: $spacing-sm;
 }
 
 .chip {
-  font-size: 0.75rem;
-  padding: 2px 8px;
-  border-radius: 9999px;
-  font-weight: 500;
+  @include xomper-chip;
+  font-size: $text-xs;
 
-  &.chip-critical { background: rgba(239, 68, 68, 0.2); color: #f87171; }
-  &.chip-info     { background: rgba(59, 130, 246, 0.2); color: #60a5fa; }
-  &.chip-active   { background: rgba(16, 185, 129, 0.2); color: #34d399; }
-  &.chip-inactive { background: rgba(255, 255, 255, 0.1); color: rgba(255, 255, 255, 0.5); }
-  &.chip-expired  { background: rgba(239, 68, 68, 0.15); color: #f87171; }
-  &.chip-expiry   { background: rgba(245, 158, 11, 0.15); color: #fbbf24; }
+  &.chip-critical { background: rgba($error-red, 0.2); color: $error-red; }
+  &.chip-info     { background: rgba($steel-blue, 0.2); color: $steel-blue; }
+  &.chip-active   { background: rgba($success-green, 0.2); color: $success-green; }
+  &.chip-inactive { background: rgba($surface-light, 0.3); color: $text-muted; }
+  &.chip-expired  { background: rgba($error-red, 0.15); color: $error-red; }
+  &.chip-expiry   { background: rgba($champion-gold, 0.15); color: $champion-gold; }
 }
 
 .row-title {
   font-weight: 600;
   margin: 0 0 4px;
+  color: $text-primary;
 }
 
 .row-body-text {
-  font-size: 0.875rem;
-  color: rgba(255, 255, 255, 0.6);
+  font-size: $text-sm;
+  color: $text-secondary;
   margin: 0 0 6px;
   white-space: pre-wrap;
   overflow: hidden;
@@ -96,16 +101,16 @@
 }
 
 .row-meta {
-  font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.4);
+  font-size: $text-xs;
+  color: $text-muted;
   margin: 0;
 }
 
 .btn-delete {
-  background: rgba(239, 68, 68, 0.15);
-  color: #f87171;
-  border: 1px solid rgba(239, 68, 68, 0.3);
-  border-radius: 8px;
+  background: rgba($error-red, 0.15);
+  color: $error-red;
+  border: 1px solid rgba($error-red, 0.3);
+  border-radius: $radius-md;
   padding: 6px 12px;
   font-size: 0.8rem;
   cursor: pointer;
@@ -115,6 +120,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: background $transition-fast;
 
   &:disabled {
     opacity: 0.5;
@@ -122,37 +128,43 @@
   }
 
   &:hover:not(:disabled) {
-    background: rgba(239, 68, 68, 0.25);
+    background: rgba($error-red, 0.25);
   }
 }
 
 .btn-primary {
-  background: #10b981;
-  color: #000;
+  background: $champion-gold;
+  color: $deep-navy;
   border: none;
-  border-radius: 8px;
-  padding: 8px 16px;
-  font-weight: 600;
+  border-radius: $radius-md;
+  padding: $spacing-sm $spacing-md;
+  font-weight: 700;
+  font-family: $font-body;
   cursor: pointer;
+  transition: filter $transition-fast;
 
-  &:hover { background: #059669; }
+  &:hover { filter: brightness(1.1); }
 }
 
 .btn-secondary {
-  background: rgba(255, 255, 255, 0.1);
-  color: #fff;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 8px;
-  padding: 8px 16px;
+  background: rgba($surface-light, 0.2);
+  color: $text-primary;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  padding: $spacing-sm $spacing-md;
+  font-family: $font-body;
   cursor: pointer;
   margin-top: 12px;
+  transition: background $transition-fast;
+
+  &:hover { background: rgba($surface-light, 0.3); }
 }
 
 .spinner-sm {
   width: 14px;
   height: 14px;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top-color: #fff;
+  border: 2px solid rgba($text-primary, 0.3);
+  border-top-color: $text-primary;
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
   display: inline-block;

--- a/src/app/pages/admin/audit/detail/admin-audit-detail.component.scss
+++ b/src/app/pages/admin/audit/detail/admin-audit-detail.component.scss
@@ -1,5 +1,9 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .audit-detail {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 760px;
   margin: 0 auto;
 }
@@ -7,16 +11,16 @@
 .detail-header {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: $spacing-md;
   margin-bottom: 28px;
 
-  h2 { margin: 0; font-size: 1.4rem; font-weight: 600; }
+  h2 { margin: 0; font-size: 1.4rem; font-weight: 600; color: $text-primary; }
 }
 
 .btn-back {
   background: none;
   border: none;
-  color: #10b981;
+  color: $champion-gold;
   cursor: pointer;
   font-size: 0.95rem;
   padding: 0;
@@ -26,26 +30,30 @@
 .state-loading {
   padding: 48px 0;
   text-align: center;
-  color: rgba(255,255,255,0.5);
+  color: $text-muted;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 12px;
-  &.state-error { color: #f87171; }
+  &.state-error { color: $error-red; }
 }
 
 .btn-secondary {
-  background: rgba(255,255,255,0.1);
-  color: #fff;
-  border: 1px solid rgba(255,255,255,0.2);
-  border-radius: 8px;
-  padding: 8px 16px;
+  background: rgba($surface-light, 0.2);
+  color: $text-primary;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  padding: $spacing-sm $spacing-md;
+  font-family: $font-body;
   cursor: pointer;
+  transition: background $transition-fast;
+
+  &:hover { background: rgba($surface-light, 0.3); }
 }
 
 .header-card {
-  background: rgba(255,255,255,0.05);
-  border-radius: 14px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.2);
   padding: 20px;
   margin-bottom: 20px;
   display: flex;
@@ -56,6 +64,7 @@
 .header-action {
   font-size: 1.1rem;
   font-weight: 700;
+  color: $text-primary;
   margin-bottom: 4px;
 }
 
@@ -64,12 +73,12 @@
   gap: 12px;
   font-size: 0.85rem;
 }
-.meta-label { color: rgba(255,255,255,0.45); min-width: 80px; }
-.meta-value { color: rgba(255,255,255,0.85); word-break: break-all; &.mono { font-family: monospace; } }
+.meta-label { color: $text-muted; min-width: 80px; }
+.meta-value { color: $text-secondary; word-break: break-all; &.mono { font-family: $font-mono; } }
 
 .json-block {
-  background: rgba(255,255,255,0.04);
-  border-radius: 10px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.15);
   margin-bottom: 12px;
   overflow: hidden;
 
@@ -77,7 +86,7 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 12px 16px;
+    padding: 12px $spacing-md;
   }
 }
 
@@ -86,38 +95,39 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 12px 16px;
+  padding: 12px $spacing-md;
   background: none;
   border: none;
   color: inherit;
   cursor: pointer;
-  font-size: 0.9rem;
-  &:hover { background: rgba(255,255,255,0.04); }
+  font-size: $text-sm;
+  transition: background $transition-fast;
+  &:hover { background: rgba($surface-light, 0.06); }
 }
 
 .block-label {
   font-weight: 600;
-  color: rgba(255,255,255,0.8);
+  color: $text-secondary;
 }
 
 .block-caret {
-  color: rgba(255,255,255,0.4);
+  color: $text-muted;
   font-size: 0.8rem;
 }
 
 .absent-label {
   font-size: 0.8rem;
-  color: rgba(255,255,255,0.3);
+  color: $text-muted;
   font-style: italic;
 }
 
 .json-pre {
   margin: 0;
-  padding: 12px 16px 16px;
-  font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
+  padding: 12px $spacing-md 16px;
+  font-family: $font-mono;
   font-size: 0.8rem;
   line-height: 1.6;
-  color: rgba(255,255,255,0.75);
+  color: $text-secondary;
   overflow-x: auto;
   white-space: pre;
 }

--- a/src/app/pages/admin/audit/feed/admin-audit-feed.component.scss
+++ b/src/app/pages/admin/audit/feed/admin-audit-feed.component.scss
@@ -1,35 +1,43 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .audit-feed {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 800px;
   margin: 0 auto;
 }
 
 .feed-header {
-  margin-bottom: 24px;
-  h2 { margin: 0; font-size: 1.5rem; font-weight: 600; }
+  margin-bottom: $spacing-lg;
+  h2 { margin: 0; font-family: $font-display; font-size: 1.5rem; font-weight: 600; color: $text-primary; }
 }
 
 .state-empty {
   text-align: center;
-  padding: 48px 16px;
-  color: rgba(255,255,255,0.5);
+  padding: 48px $spacing-md;
+  color: $text-muted;
 
-  &.state-warning { color: #f59e0b; }
-  &.state-error   { color: #ef4444; }
+  &.state-warning { color: $champion-gold; }
+  &.state-error   { color: $error-red; }
 
-  .state-title { font-weight: 600; margin-bottom: 8px; }
-  .state-body  { font-size: 0.875rem; }
-  .state-sub   { font-size: 0.875rem; margin-top: 4px; }
+  .state-title { font-weight: 600; margin-bottom: $spacing-sm; }
+  .state-body  { font-size: $text-sm; }
+  .state-sub   { font-size: $text-sm; margin-top: 4px; }
 }
 
 .btn-secondary {
   margin-top: 12px;
-  background: rgba(255,255,255,0.1);
-  color: #fff;
-  border: 1px solid rgba(255,255,255,0.2);
-  border-radius: 8px;
-  padding: 8px 16px;
+  background: rgba($surface-light, 0.2);
+  color: $text-primary;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  padding: $spacing-sm $spacing-md;
+  font-family: $font-body;
   cursor: pointer;
+  transition: background $transition-fast;
+
+  &:hover { background: rgba($surface-light, 0.3); }
 }
 
 .row-list {
@@ -38,37 +46,38 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: $spacing-sm;
 }
 
 .row-item {
-  background: rgba(255,255,255,0.05);
-  border-radius: 12px;
-  padding: 14px 16px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.1);
+  padding: 14px $spacing-md;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: border-color $transition-fast;
   display: flex;
   flex-direction: column;
   gap: 4px;
-  &:hover { background: rgba(255,255,255,0.09); }
+  &:hover { border-color: rgba($champion-gold, 0.3); }
 }
 
 .row-action {
   font-weight: 600;
   font-size: 0.95rem;
+  color: $text-primary;
 }
 
 .row-meta {
   font-size: 0.8rem;
-  color: rgba(255,255,255,0.5);
+  color: $text-secondary;
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
 }
 
 .row-date {
-  font-size: 0.75rem;
-  color: rgba(255,255,255,0.35);
+  font-size: $text-xs;
+  color: $text-muted;
 }
 
 .sentinel {
@@ -85,8 +94,8 @@
 .spinner {
   width: 24px;
   height: 24px;
-  border: 2px solid rgba(255,255,255,0.2);
-  border-top-color: #10b981;
+  border: 2px solid rgba($surface-light, 0.4);
+  border-top-color: $champion-gold;
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
   display: inline-block;

--- a/src/app/pages/admin/cron-settings/admin-cron-settings.component.scss
+++ b/src/app/pages/admin/cron-settings/admin-cron-settings.component.scss
@@ -1,51 +1,59 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .cron-settings {
   max-width: 800px;
   margin: 0 auto;
 }
 
 .test-mode-banner {
-  background: rgba(245, 158, 11, 0.15);
-  border-bottom: 1px solid rgba(245, 158, 11, 0.3);
-  color: #fbbf24;
-  font-size: 0.85rem;
+  background: rgba($champion-gold, 0.1);
+  border-bottom: 1px solid rgba($champion-gold, 0.3);
+  color: $champion-gold;
+  font-size: $text-sm;
   font-weight: 600;
   text-align: center;
-  padding: 10px 16px;
+  padding: 10px $spacing-md;
   position: sticky;
   top: 0;
   z-index: 10;
 }
 
 .page-header {
-  padding: 24px 24px 8px;
-  h2 { margin: 0; font-size: 1.5rem; font-weight: 600; }
+  padding: $spacing-lg $spacing-lg $spacing-sm;
+  h2 { margin: 0; font-family: $font-display; font-size: 1.5rem; font-weight: 600; color: $text-primary; }
 }
 
 .state-empty {
   text-align: center;
-  padding: 48px 16px;
-  color: rgba(255,255,255,0.5);
+  padding: 48px $spacing-md;
+  color: $text-muted;
 
-  &.state-warning { color: #f59e0b; }
-  &.state-error   { color: #ef4444; }
+  &.state-warning { color: $champion-gold; }
+  &.state-error   { color: $error-red; }
 
-  .state-title { font-weight: 600; margin-bottom: 8px; }
-  .state-body  { font-size: 0.875rem; }
+  .state-title { font-weight: 600; margin-bottom: $spacing-sm; }
+  .state-body  { font-size: $text-sm; }
 }
 
 .btn-secondary {
   margin-top: 12px;
-  background: rgba(255,255,255,0.1);
-  color: #fff;
-  border: 1px solid rgba(255,255,255,0.2);
-  border-radius: 8px;
-  padding: 8px 16px;
+  background: rgba($surface-light, 0.2);
+  color: $text-primary;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  padding: $spacing-sm $spacing-md;
+  font-family: $font-body;
   cursor: pointer;
+  transition: background $transition-fast;
+
+  &:hover { background: rgba($surface-light, 0.3); }
 }
 
 .row-list {
   list-style: none;
-  padding: 16px 24px;
+  padding: $spacing-md $spacing-lg;
   margin: 0;
   display: flex;
   flex-direction: column;
@@ -56,10 +64,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: rgba(255,255,255,0.05);
-  border-radius: 12px;
-  padding: 16px;
-  gap: 16px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.2);
+  padding: $spacing-md;
+  gap: $spacing-md;
 }
 
 .row-info {
@@ -73,21 +81,22 @@
 .row-title {
   font-weight: 600;
   font-size: 0.95rem;
+  color: $text-primary;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .row-key {
-  font-size: 0.75rem;
-  color: rgba(255,255,255,0.4);
-  font-family: monospace;
+  font-size: $text-xs;
+  color: $text-muted;
+  font-family: $font-mono;
 }
 
 .row-controls {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: $spacing-md;
   flex-shrink: 0;
 }
 
@@ -105,8 +114,8 @@
 
 .toggle-label {
   font-size: 0.7rem;
-  color: rgba(255,255,255,0.6);
-  &.toggle-label--off { color: rgba(255,255,255,0.3); }
+  color: $text-secondary;
+  &.toggle-label--off { color: $text-muted; }
 }
 
 .toggle {
@@ -130,12 +139,12 @@
   }
 
   &.toggle--on {
-    background: #10b981;
+    background: $champion-gold;
     &::after { left: 23px; }
   }
 
   &.toggle--off {
-    background: rgba(255,255,255,0.2);
+    background: rgba($surface-light, 0.5);
     &::after { left: 3px; }
   }
 
@@ -145,8 +154,8 @@
 .spinner-sm {
   width: 20px;
   height: 20px;
-  border: 2px solid rgba(255,255,255,0.2);
-  border-top-color: #10b981;
+  border: 2px solid rgba($surface-light, 0.4);
+  border-top-color: $champion-gold;
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
   display: inline-block;

--- a/src/app/pages/admin/email-archive/detail/admin-email-archive-detail.component.scss
+++ b/src/app/pages/admin/email-archive/detail/admin-email-archive-detail.component.scss
@@ -1,36 +1,41 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .archive-detail {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 800px;
   margin: 0 auto;
 }
 
-.back-row { margin-bottom: 16px; }
+.back-row { margin-bottom: $spacing-md; }
 
 .btn-back {
   background: none;
   border: none;
-  color: var(--color-success-green, #4caf50);
-  font-size: 0.875rem;
+  color: $champion-gold;
+  font-size: $text-sm;
   cursor: pointer;
   padding: 0;
+  transition: opacity $transition-fast;
 
   &:hover { opacity: 0.8; }
 }
 
 .loading-state,
 .error-state {
-  font-size: 0.875rem;
-  padding: 16px 0;
+  font-size: $text-sm;
+  padding: $spacing-md 0;
+  color: $text-secondary;
 }
 
-.error-state { color: var(--color-error-red, #e53935); }
+.error-state { color: $error-red; }
 
 .meta-card {
-  background: var(--color-surface-elevated, #1e2a1e);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 12px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.2);
   padding: 20px;
-  margin-bottom: 24px;
+  margin-bottom: $spacing-lg;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -40,44 +45,42 @@
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  gap: 16px;
-  font-size: 0.875rem;
+  gap: $spacing-md;
+  font-size: $text-sm;
 }
 
 .meta-label {
-  color: var(--color-text-secondary, #a5c8a5);
+  color: $text-secondary;
   flex-shrink: 0;
   font-size: 0.8125rem;
   min-width: 80px;
 }
 
 .meta-value {
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
   font-weight: 500;
   text-align: right;
   word-break: break-all;
 
   &.mono {
-    font-family: monospace;
-    font-size: 0.75rem;
+    font-family: $font-mono;
+    font-size: $text-xs;
   }
 }
 
 .template-chip {
-  font-size: 0.7rem;
-  font-weight: 600;
-  padding: 2px 7px;
-  border-radius: 4px;
-  background: rgba(76, 175, 80, 0.12);
-  color: var(--color-success-green, #4caf50);
+  @include xomper-chip;
+  font-size: $text-xs;
+  background: rgba($success-green, 0.12);
+  color: $success-green;
 }
 
-.section { margin-bottom: 32px; }
+.section { margin-bottom: $spacing-xl; }
 
 .section-title {
-  font-size: 0.875rem;
+  font-size: $text-sm;
   font-weight: 600;
-  color: var(--color-text-secondary, #a5c8a5);
+  color: $text-secondary;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   margin: 0 0 12px;
@@ -85,39 +88,38 @@
 
 .html-preview {
   background: #fff;
-  border-radius: 8px;
-  padding: 16px;
+  border-radius: $radius-md;
+  padding: $spacing-md;
   overflow: auto;
   max-height: 600px;
   color: #000;
-  font-size: 0.875rem;
+  font-size: $text-sm;
   line-height: 1.6;
 }
 
 .text-body {
-  background: var(--color-surface-elevated, #1e2a1e);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 8px;
-  padding: 16px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.2);
+  padding: $spacing-md;
   font-size: 0.8125rem;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
   white-space: pre-wrap;
   word-break: break-word;
   overflow-x: auto;
   margin: 0;
+  font-family: $font-mono;
 }
 
 .resend-section {
-  background: var(--color-surface-elevated, #1e2a1e);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 12px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.2);
   padding: 20px;
 }
 
 .resend-form {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: $spacing-md;
 }
 
 .form-field {
@@ -129,56 +131,59 @@
 .field-label {
   font-size: 0.8125rem;
   font-weight: 600;
-  color: var(--color-text-secondary, #a5c8a5);
+  color: $text-secondary;
 }
 
 .field-input {
-  background: var(--color-surface, #132013);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 8px;
-  color: var(--color-text-primary, #e8f5e9);
-  font-size: 0.875rem;
+  background: $bg-input;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  color: $text-primary;
+  font-size: $text-sm;
   padding: 10px 12px;
+  font-family: $font-body;
 
-  &::placeholder { color: var(--color-text-muted, #6b8c6b); }
-  &:focus { outline: none; border-color: var(--color-success-green, #4caf50); }
+  &::placeholder { color: $text-muted; }
+  &:focus { outline: none; border-color: $champion-gold; }
 }
 
 .field-hint {
-  font-size: 0.75rem;
-  color: var(--color-text-muted, #6b8c6b);
+  font-size: $text-xs;
+  color: $text-muted;
 }
 
 .btn-resend {
-  background: var(--color-success-green, #4caf50);
-  color: #fff;
+  background: $champion-gold;
+  color: $deep-navy;
   border: none;
-  border-radius: 8px;
+  border-radius: $radius-md;
   padding: 10px;
-  font-size: 0.875rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: 700;
+  font-family: $font-body;
   cursor: pointer;
-  transition: opacity 0.15s;
+  transition: filter $transition-fast;
 
   &:disabled { opacity: 0.4; cursor: not-allowed; }
+  &:hover:not(:disabled) { filter: brightness(1.1); }
 }
 
 .success-msg {
   padding: 10px 12px;
-  background: rgba(76, 175, 80, 0.1);
-  border: 1px solid var(--color-success-green, #4caf50);
-  border-radius: 8px;
-  font-size: 0.875rem;
-  color: var(--color-success-green, #4caf50);
-  margin-top: 8px;
+  background: rgba($success-green, 0.1);
+  border: 1px solid $success-green;
+  border-radius: $radius-md;
+  font-size: $text-sm;
+  color: $success-green;
+  margin-top: $spacing-sm;
 }
 
 .error-msg {
   padding: 10px 12px;
-  background: rgba(229, 57, 53, 0.1);
-  border: 1px solid var(--color-error-red, #e53935);
-  border-radius: 8px;
-  font-size: 0.875rem;
-  color: var(--color-error-red, #e53935);
-  margin-top: 8px;
+  background: rgba($error-red, 0.1);
+  border: 1px solid $error-red;
+  border-radius: $radius-md;
+  font-size: $text-sm;
+  color: $error-red;
+  margin-top: $spacing-sm;
 }

--- a/src/app/pages/admin/email-archive/list/admin-email-archive-list.component.scss
+++ b/src/app/pages/admin/email-archive/list/admin-email-archive-list.component.scss
@@ -1,21 +1,26 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .archive-list {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 800px;
   margin: 0 auto;
 }
 
-.page-header { margin-bottom: 24px; }
+.page-header { margin-bottom: $spacing-lg; }
 
 .page-title {
+  font-family: $font-display;
   font-size: 1.5rem;
   font-weight: 700;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
   margin: 0 0 4px;
 }
 
 .page-subtitle {
-  font-size: 0.875rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-sm;
+  color: $text-secondary;
   margin: 0;
 }
 
@@ -24,13 +29,13 @@
 .empty-state,
 .loading-more,
 .end-of-list {
-  font-size: 0.875rem;
-  color: var(--color-text-secondary, #a5c8a5);
-  padding: 16px 0;
+  font-size: $text-sm;
+  color: $text-secondary;
+  padding: $spacing-md 0;
   text-align: center;
 }
 
-.error-state { color: var(--color-error-red, #e53935); }
+.error-state { color: $error-red; }
 
 .rows-list {
   list-style: none;
@@ -38,21 +43,20 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: $spacing-sm;
 }
 
 .row-item {
   display: flex;
   align-items: center;
-  gap: 16px;
-  background: var(--color-surface-elevated, #1e2a1e);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 10px;
-  padding: 14px 16px;
+  gap: $spacing-md;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.2);
+  padding: 14px $spacing-md;
   cursor: pointer;
-  transition: border-color 0.15s;
+  transition: border-color $transition-fast;
 
-  &:hover { border-color: var(--color-success-green, #4caf50); }
+  &:hover { border-color: rgba($champion-gold, 0.4); }
 }
 
 .row-left {
@@ -64,24 +68,22 @@
 }
 
 .row-template {
-  font-size: 0.7rem;
-  font-weight: 600;
-  padding: 2px 7px;
-  border-radius: 4px;
-  background: rgba(76, 175, 80, 0.12);
-  color: var(--color-success-green, #4caf50);
+  @include xomper-chip;
+  font-size: $text-xs;
+  background: rgba($success-green, 0.12);
+  color: $success-green;
   width: fit-content;
-  letter-spacing: 0.03em;
 
   &.no-template {
     background: none;
-    color: var(--color-text-muted, #6b8c6b);
+    color: $text-muted;
+    border: none;
   }
 }
 
 .row-subject {
-  font-size: 0.875rem;
-  color: var(--color-text-primary, #e8f5e9);
+  font-size: $text-sm;
+  color: $text-primary;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -96,23 +98,23 @@
 }
 
 .row-recipient {
-  font-size: 0.75rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-xs;
+  color: $text-secondary;
 }
 
 .row-date {
-  font-size: 0.75rem;
-  color: var(--color-text-muted, #6b8c6b);
+  font-size: $text-xs;
+  color: $text-muted;
   white-space: nowrap;
 }
 
 .chevron {
-  color: var(--color-text-secondary, #a5c8a5);
+  color: $text-secondary;
   font-size: 1.25rem;
   flex-shrink: 0;
 }
 
 .scroll-sentinel {
   height: 1px;
-  margin-top: 8px;
+  margin-top: $spacing-sm;
 }

--- a/src/app/pages/admin/logs/admin-logs.component.scss
+++ b/src/app/pages/admin/logs/admin-logs.component.scss
@@ -1,9 +1,13 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .logs-placeholder {
   display: flex;
   align-items: center;
   justify-content: center;
   min-height: 60vh;
-  padding: 24px;
+  padding: $spacing-lg;
 }
 
 .placeholder-card {
@@ -18,25 +22,25 @@
 .terminal-icon {
   font-size: 3rem;
   line-height: 1;
-  color: rgba(255,255,255,0.3);
+  color: $text-muted;
 }
 
 h3 {
   font-size: 1.2rem;
   font-weight: 600;
   margin: 0;
-  color: rgba(255,255,255,0.7);
+  color: $text-secondary;
 }
 
 p {
-  font-size: 0.9rem;
-  color: rgba(255,255,255,0.4);
+  font-size: $text-sm;
+  color: $text-muted;
   margin: 0;
 }
 
 .console-link {
-  font-size: 0.85rem;
-  color: #10b981;
+  font-size: $text-sm;
+  color: $champion-gold;
   text-decoration: none;
   margin-top: 4px;
   &:hover { text-decoration: underline; }

--- a/src/app/pages/admin/tables/admin-tables-menu.component.scss
+++ b/src/app/pages/admin/tables/admin-tables-menu.component.scss
@@ -1,56 +1,64 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .tables-menu {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 700px;
   margin: 0 auto;
 }
 
 .menu-header {
-  margin-bottom: 24px;
+  margin-bottom: $spacing-lg;
 
   h2 {
     margin: 0;
+    font-family: $font-display;
     font-size: 1.5rem;
     font-weight: 600;
+    color: $text-primary;
   }
 }
 
 .tile-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 16px;
+  gap: $spacing-md;
 }
 
 .tile {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 16px;
-  padding: 24px 20px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.2);
+  padding: $spacing-lg 20px;
   cursor: pointer;
   color: inherit;
   text-align: left;
-  transition: background 0.15s;
+  transition: border-color $transition-fast, background $transition-fast;
   display: flex;
   flex-direction: column;
   gap: 6px;
   position: relative;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.1);
+    background: $bg-card-hover;
+    border-color: rgba($champion-gold, 0.4);
   }
 }
 
 .tile-label {
   font-size: 1.05rem;
   font-weight: 600;
+  color: $text-primary;
 }
 
 .tile-subtitle {
   font-size: 0.8rem;
-  color: rgba(255, 255, 255, 0.5);
+  color: $text-secondary;
 }
 
 .tile-badge {
-  font-size: 0.7rem;
-  color: #10b981;
+  @include xomper-chip-outline;
+  font-size: $text-xs;
   margin-top: 4px;
+  width: fit-content;
 }

--- a/src/app/pages/admin/tables/leagues/edit/admin-league-edit.component.scss
+++ b/src/app/pages/admin/tables/leagues/edit/admin-league-edit.component.scss
@@ -1,5 +1,9 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .league-edit {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 560px;
   margin: 0 auto;
 }
@@ -7,16 +11,16 @@
 .edit-header {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: $spacing-md;
   margin-bottom: 28px;
 
-  h2 { margin: 0; font-size: 1.4rem; font-weight: 600; }
+  h2 { margin: 0; font-size: 1.4rem; font-weight: 600; color: $text-primary; }
 }
 
 .btn-back {
   background: none;
   border: none;
-  color: #10b981;
+  color: $champion-gold;
   cursor: pointer;
   font-size: 0.95rem;
   padding: 0;
@@ -24,18 +28,18 @@
 }
 
 .readonly-section {
-  background: rgba(255,255,255,0.04);
-  border-radius: 10px;
-  padding: 14px 16px;
-  margin-bottom: 24px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.15);
+  padding: 14px $spacing-md;
+  margin-bottom: $spacing-lg;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: $spacing-sm;
 }
 
 .readonly-row { display: flex; gap: 12px; font-size: 0.85rem; }
-.readonly-label { color: rgba(255,255,255,0.5); min-width: 100px; }
-.readonly-value { color: rgba(255,255,255,0.8); font-family: monospace; word-break: break-all; }
+.readonly-label { color: $text-muted; min-width: 100px; }
+.readonly-value { color: $text-secondary; font-family: $font-mono; word-break: break-all; }
 
 .edit-form { display: flex; flex-direction: column; gap: 18px; }
 
@@ -51,68 +55,73 @@
     label { margin-bottom: 0; }
   }
 
-  label { font-size: 0.875rem; font-weight: 500; color: rgba(255,255,255,0.7); }
+  label { font-size: $text-sm; font-weight: 500; color: $text-secondary; }
 }
 
 input[type="text"] {
-  background: rgba(255,255,255,0.07);
-  border: 1px solid rgba(255,255,255,0.15);
-  border-radius: 8px;
-  color: #fff;
-  font-size: 0.9rem;
+  background: $bg-input;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  color: $text-primary;
+  font-size: $text-sm;
   padding: 10px 12px;
   outline: none;
-  &:focus { border-color: #10b981; }
-  &::placeholder { color: rgba(255,255,255,0.3); }
+  font-family: $font-body;
+  &:focus { border-color: $champion-gold; }
+  &::placeholder { color: $text-muted; }
 }
 
-input[type="checkbox"] { width: 18px; height: 18px; cursor: pointer; }
+input[type="checkbox"] { width: 18px; height: 18px; cursor: pointer; accent-color: $champion-gold; }
 
-.field-error { font-size: 0.75rem; color: #f87171; margin: 0; }
-.feedback-error   { color: #f87171; font-size: 0.875rem; margin: 0; }
-.feedback-success { color: #34d399; font-size: 0.875rem; margin: 0; }
-.error-text { color: #f87171; }
+.field-error { font-size: $text-xs; color: $error-red; margin: 0; }
+.feedback-error   { color: $error-red; font-size: $text-sm; margin: 0; }
+.feedback-success { color: $success-green; font-size: $text-sm; margin: 0; }
+.error-text { color: $error-red; }
 
 .form-actions {
   display: flex;
   gap: 12px;
-  margin-top: 8px;
+  margin-top: $spacing-sm;
 
   .btn-secondary {
     flex: 1;
-    background: rgba(255,255,255,0.1);
-    color: #fff;
-    border: 1px solid rgba(255,255,255,0.2);
-    border-radius: 8px;
+    background: rgba($surface-light, 0.2);
+    color: $text-primary;
+    border: 1px solid rgba($surface-light, 0.4);
+    border-radius: $radius-md;
     padding: 10px;
-    font-size: 0.9rem;
+    font-size: $text-sm;
+    font-family: $font-body;
     cursor: pointer;
-    &:hover { background: rgba(255,255,255,0.15); }
+    transition: background $transition-fast;
+    &:hover { background: rgba($surface-light, 0.3); }
   }
 
   .btn-primary {
     flex: 2;
-    background: #10b981;
-    color: #000;
+    background: $champion-gold;
+    color: $deep-navy;
     border: none;
-    border-radius: 8px;
+    border-radius: $radius-md;
     padding: 10px;
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: 700;
+    font-family: $font-body;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 8px;
+    gap: $spacing-sm;
+    transition: filter $transition-fast;
     &:disabled { opacity: 0.5; cursor: not-allowed; }
-    &:hover:not(:disabled) { background: #059669; }
+    &:hover:not(:disabled) { filter: brightness(1.1); }
   }
 }
 
 .state-loading {
   padding: 48px 0;
   text-align: center;
-  color: rgba(255,255,255,0.5);
+  color: $text-muted;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -120,19 +129,22 @@ input[type="checkbox"] { width: 18px; height: 18px; cursor: pointer; }
 }
 
 .btn-secondary {
-  background: rgba(255,255,255,0.1);
-  color: #fff;
-  border: 1px solid rgba(255,255,255,0.2);
-  border-radius: 8px;
-  padding: 8px 16px;
+  background: rgba($surface-light, 0.2);
+  color: $text-primary;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  padding: $spacing-sm $spacing-md;
+  font-family: $font-body;
   cursor: pointer;
+  transition: background $transition-fast;
+  &:hover { background: rgba($surface-light, 0.3); }
 }
 
 .spinner-sm {
   width: 16px;
   height: 16px;
-  border: 2px solid rgba(0,0,0,0.3);
-  border-top-color: #000;
+  border: 2px solid rgba($deep-navy, 0.3);
+  border-top-color: $deep-navy;
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
   display: inline-block;

--- a/src/app/pages/admin/tables/leagues/list/admin-tables-leagues.component.scss
+++ b/src/app/pages/admin/tables/leagues/list/admin-tables-leagues.component.scss
@@ -1,29 +1,36 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .leagues-list {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 700px;
   margin: 0 auto;
 }
 
 .list-header {
-  margin-bottom: 24px;
-  h2 { margin: 0; font-size: 1.5rem; font-weight: 600; }
+  margin-bottom: $spacing-lg;
+  h2 { margin: 0; font-family: $font-display; font-size: 1.5rem; font-weight: 600; color: $text-primary; }
 }
 
 .state-empty {
   text-align: center;
-  padding: 48px 16px;
-  color: rgba(255,255,255,0.5);
-  &.state-error { color: #f87171; }
+  padding: 48px $spacing-md;
+  color: $text-muted;
+  &.state-error { color: $error-red; }
 }
 
 .btn-secondary {
   margin-top: 12px;
-  background: rgba(255,255,255,0.1);
-  color: #fff;
-  border: 1px solid rgba(255,255,255,0.2);
-  border-radius: 8px;
-  padding: 8px 16px;
+  background: rgba($surface-light, 0.2);
+  color: $text-primary;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  padding: $spacing-sm $spacing-md;
+  font-family: $font-body;
   cursor: pointer;
+  transition: background $transition-fast;
+  &:hover { background: rgba($surface-light, 0.3); }
 }
 
 .row-list {
@@ -32,19 +39,19 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: $spacing-sm;
 }
 
 .row-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: rgba(255,255,255,0.05);
-  border-radius: 12px;
-  padding: 14px 16px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.15);
+  padding: 14px $spacing-md;
   cursor: pointer;
-  transition: background 0.15s;
-  &:hover { background: rgba(255,255,255,0.09); }
+  transition: border-color $transition-fast;
+  &:hover { border-color: rgba($champion-gold, 0.4); }
 }
 
 .row-info {
@@ -55,8 +62,8 @@
   min-width: 0;
 }
 
-.row-name { font-weight: 600; font-size: 0.95rem; }
-.row-meta { font-size: 0.78rem; color: rgba(255,255,255,0.45); }
+.row-name { font-weight: 600; font-size: 0.95rem; color: $text-primary; }
+.row-meta { font-size: 0.78rem; color: $text-muted; }
 
 .row-chips {
   display: flex;
@@ -68,13 +75,13 @@
 }
 
 .chip {
-  font-size: 0.72rem;
-  padding: 2px 8px;
+  font-size: $text-xs;
+  padding: 2px $spacing-sm;
   border-radius: 9999px;
   font-weight: 500;
   white-space: nowrap;
 
-  &.chip-active   { background: rgba(16,185,129,0.2); color: #34d399; }
-  &.chip-inactive { background: rgba(255,255,255,0.08); color: rgba(255,255,255,0.4); }
-  &.chip-tag      { background: rgba(255,255,255,0.1); color: rgba(255,255,255,0.7); }
+  &.chip-active   { background: rgba($success-green, 0.2); color: $success-green; }
+  &.chip-inactive { background: rgba($surface-light, 0.3); color: $text-muted; }
+  &.chip-tag      { background: rgba($surface-light, 0.2); color: $text-secondary; }
 }

--- a/src/app/pages/admin/tables/users/edit/admin-user-edit.component.scss
+++ b/src/app/pages/admin/tables/users/edit/admin-user-edit.component.scss
@@ -1,5 +1,9 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .user-edit {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 560px;
   margin: 0 auto;
 }
@@ -7,16 +11,16 @@
 .edit-header {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: $spacing-md;
   margin-bottom: 28px;
 
-  h2 { margin: 0; font-size: 1.4rem; font-weight: 600; }
+  h2 { margin: 0; font-size: 1.4rem; font-weight: 600; color: $text-primary; }
 }
 
 .btn-back {
   background: none;
   border: none;
-  color: #10b981;
+  color: $champion-gold;
   cursor: pointer;
   font-size: 0.95rem;
   padding: 0;
@@ -24,22 +28,18 @@
 }
 
 .readonly-section {
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 10px;
-  padding: 14px 16px;
-  margin-bottom: 24px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.15);
+  padding: 14px $spacing-md;
+  margin-bottom: $spacing-lg;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: $spacing-sm;
 }
 
-.readonly-row {
-  display: flex;
-  gap: 12px;
-  font-size: 0.85rem;
-}
-.readonly-label { color: rgba(255,255,255,0.5); min-width: 100px; }
-.readonly-value { color: rgba(255,255,255,0.8); font-family: monospace; word-break: break-all; }
+.readonly-row { display: flex; gap: 12px; font-size: 0.85rem; }
+.readonly-label { color: $text-muted; min-width: 100px; }
+.readonly-value { color: $text-secondary; font-family: $font-mono; word-break: break-all; }
 
 .edit-form {
   display: flex;
@@ -59,68 +59,73 @@
     label { margin-bottom: 0; }
   }
 
-  label { font-size: 0.875rem; font-weight: 500; color: rgba(255,255,255,0.7); }
+  label { font-size: $text-sm; font-weight: 500; color: $text-secondary; }
 }
 
 input[type="text"], input[type="email"] {
-  background: rgba(255,255,255,0.07);
-  border: 1px solid rgba(255,255,255,0.15);
-  border-radius: 8px;
-  color: #fff;
-  font-size: 0.9rem;
+  background: $bg-input;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  color: $text-primary;
+  font-size: $text-sm;
   padding: 10px 12px;
   outline: none;
-  &:focus { border-color: #10b981; }
-  &::placeholder { color: rgba(255,255,255,0.3); }
+  font-family: $font-body;
+  &:focus { border-color: $champion-gold; }
+  &::placeholder { color: $text-muted; }
 }
 
-input[type="checkbox"] { width: 18px; height: 18px; cursor: pointer; }
+input[type="checkbox"] { width: 18px; height: 18px; cursor: pointer; accent-color: $champion-gold; }
 
-.field-error { font-size: 0.75rem; color: #f87171; margin: 0; }
-.feedback-error   { color: #f87171; font-size: 0.875rem; margin: 0; }
-.feedback-success { color: #34d399; font-size: 0.875rem; margin: 0; }
-.error-text { color: #f87171; }
+.field-error { font-size: $text-xs; color: $error-red; margin: 0; }
+.feedback-error   { color: $error-red; font-size: $text-sm; margin: 0; }
+.feedback-success { color: $success-green; font-size: $text-sm; margin: 0; }
+.error-text { color: $error-red; }
 
 .form-actions {
   display: flex;
   gap: 12px;
-  margin-top: 8px;
+  margin-top: $spacing-sm;
 
   .btn-secondary {
     flex: 1;
-    background: rgba(255,255,255,0.1);
-    color: #fff;
-    border: 1px solid rgba(255,255,255,0.2);
-    border-radius: 8px;
+    background: rgba($surface-light, 0.2);
+    color: $text-primary;
+    border: 1px solid rgba($surface-light, 0.4);
+    border-radius: $radius-md;
     padding: 10px;
-    font-size: 0.9rem;
+    font-size: $text-sm;
+    font-family: $font-body;
     cursor: pointer;
-    &:hover { background: rgba(255,255,255,0.15); }
+    transition: background $transition-fast;
+    &:hover { background: rgba($surface-light, 0.3); }
   }
 
   .btn-primary {
     flex: 2;
-    background: #10b981;
-    color: #000;
+    background: $champion-gold;
+    color: $deep-navy;
     border: none;
-    border-radius: 8px;
+    border-radius: $radius-md;
     padding: 10px;
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: 700;
+    font-family: $font-body;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 8px;
+    gap: $spacing-sm;
+    transition: filter $transition-fast;
     &:disabled { opacity: 0.5; cursor: not-allowed; }
-    &:hover:not(:disabled) { background: #059669; }
+    &:hover:not(:disabled) { filter: brightness(1.1); }
   }
 }
 
 .state-loading {
   padding: 48px 0;
   text-align: center;
-  color: rgba(255,255,255,0.5);
+  color: $text-muted;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -128,19 +133,22 @@ input[type="checkbox"] { width: 18px; height: 18px; cursor: pointer; }
 }
 
 .btn-secondary {
-  background: rgba(255,255,255,0.1);
-  color: #fff;
-  border: 1px solid rgba(255,255,255,0.2);
-  border-radius: 8px;
-  padding: 8px 16px;
+  background: rgba($surface-light, 0.2);
+  color: $text-primary;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  padding: $spacing-sm $spacing-md;
+  font-family: $font-body;
   cursor: pointer;
+  transition: background $transition-fast;
+  &:hover { background: rgba($surface-light, 0.3); }
 }
 
 .spinner-sm {
   width: 16px;
   height: 16px;
-  border: 2px solid rgba(0,0,0,0.3);
-  border-top-color: #000;
+  border: 2px solid rgba($deep-navy, 0.3);
+  border-top-color: $deep-navy;
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
   display: inline-block;

--- a/src/app/pages/admin/tables/users/list/admin-tables-users.component.scss
+++ b/src/app/pages/admin/tables/users/list/admin-tables-users.component.scss
@@ -1,30 +1,36 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .users-list {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 700px;
   margin: 0 auto;
 }
 
 .list-header {
-  margin-bottom: 24px;
-
-  h2 { margin: 0; font-size: 1.5rem; font-weight: 600; }
+  margin-bottom: $spacing-lg;
+  h2 { margin: 0; font-family: $font-display; font-size: 1.5rem; font-weight: 600; color: $text-primary; }
 }
 
 .state-empty {
   text-align: center;
-  padding: 48px 16px;
-  color: rgba(255, 255, 255, 0.5);
-  &.state-error { color: #f87171; }
+  padding: 48px $spacing-md;
+  color: $text-muted;
+  &.state-error { color: $error-red; }
 }
 
 .btn-secondary {
   margin-top: 12px;
-  background: rgba(255, 255, 255, 0.1);
-  color: #fff;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 8px;
-  padding: 8px 16px;
+  background: rgba($surface-light, 0.2);
+  color: $text-primary;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  padding: $spacing-sm $spacing-md;
+  font-family: $font-body;
   cursor: pointer;
+  transition: background $transition-fast;
+  &:hover { background: rgba($surface-light, 0.3); }
 }
 
 .row-list {
@@ -33,20 +39,20 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: $spacing-sm;
 }
 
 .row-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 12px;
-  padding: 14px 16px;
+  @include xomper-card;
+  border: 1px solid rgba($surface-light, 0.15);
+  padding: 14px $spacing-md;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: border-color $transition-fast;
 
-  &:hover { background: rgba(255, 255, 255, 0.09); }
+  &:hover { border-color: rgba($champion-gold, 0.4); }
 }
 
 .row-info {
@@ -60,6 +66,7 @@
 .row-name {
   font-weight: 600;
   font-size: 0.95rem;
+  color: $text-primary;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -67,7 +74,7 @@
 
 .row-email {
   font-size: 0.8rem;
-  color: rgba(255, 255, 255, 0.5);
+  color: $text-muted;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -81,14 +88,14 @@
 }
 
 .chip {
-  font-size: 0.72rem;
-  padding: 2px 8px;
+  font-size: $text-xs;
+  padding: 2px $spacing-sm;
   border-radius: 9999px;
   font-weight: 500;
   white-space: nowrap;
 
-  &.chip-admin    { background: rgba(16, 185, 129, 0.2); color: #34d399; }
-  &.chip-member   { background: rgba(255, 255, 255, 0.08); color: rgba(255,255,255,0.6); }
-  &.chip-active   { background: rgba(16, 185, 129, 0.15); color: #34d399; }
-  &.chip-inactive { background: rgba(255,255,255,0.08); color: rgba(255,255,255,0.4); }
+  &.chip-admin    { background: rgba($champion-gold, 0.2); color: $champion-gold; }
+  &.chip-member   { background: rgba($surface-light, 0.3); color: $text-secondary; }
+  &.chip-active   { background: rgba($success-green, 0.15); color: $success-green; }
+  &.chip-inactive { background: rgba($surface-light, 0.2); color: $text-muted; }
 }

--- a/src/app/pages/admin/test-email/admin-test-email.component.scss
+++ b/src/app/pages/admin/test-email/admin-test-email.component.scss
@@ -1,21 +1,26 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
+
 .test-email-screen {
-  padding: 24px;
+  padding: $spacing-lg;
   max-width: 560px;
   margin: 0 auto;
 }
 
-.page-header { margin-bottom: 32px; }
+.page-header { margin-bottom: $spacing-xl; }
 
 .page-title {
+  font-family: $font-display;
   font-size: 1.5rem;
   font-weight: 700;
-  color: var(--color-text-primary, #e8f5e9);
+  color: $text-primary;
   margin: 0 0 4px;
 }
 
 .page-subtitle {
-  font-size: 0.875rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  font-size: $text-sm;
+  color: $text-secondary;
   margin: 0;
 }
 
@@ -34,64 +39,67 @@
 .field-label {
   font-size: 0.8125rem;
   font-weight: 600;
-  color: var(--color-text-secondary, #a5c8a5);
+  color: $text-secondary;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
 .field-select {
-  background: var(--color-surface-elevated, #1e2a1e);
-  border: 1px solid var(--color-border, #2d3f2d);
-  border-radius: 8px;
-  color: var(--color-text-primary, #e8f5e9);
-  font-size: 0.875rem;
+  background: $bg-input;
+  border: 1px solid rgba($surface-light, 0.4);
+  border-radius: $radius-md;
+  color: $text-primary;
+  font-size: $text-sm;
   padding: 10px 12px;
   appearance: auto;
   cursor: pointer;
+  font-family: $font-body;
 
   &:focus {
     outline: none;
-    border-color: var(--color-success-green, #4caf50);
+    border-color: $champion-gold;
   }
 
   option {
-    background: var(--color-surface, #132013);
+    background: $bg-dark;
   }
 }
 
 .loading-inline {
   font-size: 0.8125rem;
-  color: var(--color-text-secondary, #a5c8a5);
+  color: $text-secondary;
 }
 
 .btn-send {
-  background: var(--color-success-green, #4caf50);
-  color: #fff;
+  background: $champion-gold;
+  color: $deep-navy;
   border: none;
-  border-radius: 8px;
+  border-radius: $radius-md;
   padding: 12px;
   font-size: 0.9375rem;
-  font-weight: 600;
+  font-weight: 700;
+  font-family: $font-body;
   cursor: pointer;
-  transition: opacity 0.15s;
+  transition: filter $transition-fast;
 
   &:disabled { opacity: 0.4; cursor: not-allowed; }
+  &:hover:not(:disabled) { filter: brightness(1.1); }
 }
 
 .success-msg {
   padding: 12px;
-  background: rgba(76, 175, 80, 0.1);
-  border: 1px solid var(--color-success-green, #4caf50);
-  border-radius: 8px;
-  font-size: 0.875rem;
-  color: var(--color-success-green, #4caf50);
+  background: rgba($success-green, 0.1);
+  border: 1px solid $success-green;
+  border-radius: $radius-md;
+  font-size: $text-sm;
+  color: $success-green;
 }
 
 .error-msg {
   padding: 12px;
-  background: rgba(229, 57, 53, 0.1);
-  border: 1px solid var(--color-error-red, #e53935);
-  border-radius: 8px;
-  font-size: 0.875rem;
-  color: var(--color-error-red, #e53935);
+  background: rgba($error-red, 0.1);
+  border: 1px solid $error-red;
+  border-radius: $radius-md;
+  font-size: $text-sm;
+  color: $error-red;
 }

--- a/src/app/pages/draft-history/draft-history.component.scss
+++ b/src/app/pages/draft-history/draft-history.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .draft-history-page {
   min-height: 100vh;
@@ -59,7 +60,7 @@
   transition: all $transition-base;
 
   &.active {
-    background: $gold-accent;
+    background: $champion-gold;
     color: $deep-navy;
     border-color: $champion-gold;
   }

--- a/src/app/pages/draft-history/live/draft-live.component.scss
+++ b/src/app/pages/draft-history/live/draft-live.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .draft-live {
   min-height: 200px;
@@ -119,7 +120,7 @@
   font-family: $font-mono;
 
   &.active {
-    background: $gold-accent;
+    background: $champion-gold;
     color: $deep-navy;
   }
 
@@ -211,7 +212,7 @@
   flex-shrink: 0;
 
   .pick-made & {
-    background: $gold-accent;
+    background: $champion-gold;
     color: $deep-navy;
   }
 }

--- a/src/app/pages/draft-history/mocks/draft-mocks.component.scss
+++ b/src/app/pages/draft-history/mocks/draft-mocks.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .draft-mocks {
   min-height: 200px;

--- a/src/app/pages/draft-history/picks/draft-picks.component.scss
+++ b/src/app/pages/draft-history/picks/draft-picks.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 // Empty State
 .empty-state {
@@ -75,7 +76,7 @@
   left: $spacing-sm;
   width: 32px;
   height: 32px;
-  background: $gold-accent;
+  background: $champion-gold;
   color: $deep-navy;
   border-radius: $radius-full;
   display: flex;

--- a/src/app/pages/draft-history/recap/draft-recap.component.scss
+++ b/src/app/pages/draft-history/recap/draft-recap.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .draft-recap {
   min-height: 200px;

--- a/src/app/pages/league/draft-order/draft-order.component.scss
+++ b/src/app/pages/league/draft-order/draft-order.component.scss
@@ -1,19 +1,22 @@
 // Draft Order Projection — Reverse-HPP
-// Midnight Emerald dark theme. Full polish deferred to s10.
+// Midnight Emerald dark theme — s10 sweep: migrated from --color-* to --xomper-* tokens.
+@import 'styles/variables';
+@import 'styles/mixins';
+@import 'styles/theme';
 
 .draft-order-progress {
   padding: 24px 16px;
   text-align: center;
 
   .progress-label {
-    font-size: 0.85rem;
-    color: var(--color-text-secondary, #9ca3af);
+    font-size: $text-sm;
+    color: $text-secondary;
     margin-bottom: 12px;
   }
 
   .progress-bar-track {
     height: 4px;
-    background: var(--color-surface-elevated, #1f2937);
+    background: rgba($surface-light, 0.4);
     border-radius: 2px;
     overflow: hidden;
     max-width: 300px;
@@ -22,7 +25,7 @@
 
   .progress-bar-fill {
     height: 100%;
-    background: var(--color-accent, #10b981);
+    background: $champion-gold;
     border-radius: 2px;
     transition: width 0.3s ease;
   }
@@ -31,8 +34,8 @@
 .draft-order-error {
   padding: 32px 16px;
   text-align: center;
-  color: var(--color-danger, #ef4444);
-  font-size: 0.9rem;
+  color: $error-red;
+  font-size: $text-sm;
 }
 
 .draft-order-pending {
@@ -47,13 +50,13 @@
   .pending-title {
     font-size: 1.1rem;
     font-weight: 600;
-    color: var(--color-text-primary, #f9fafb);
+    color: $text-primary;
     margin: 0 0 8px;
   }
 
   .pending-desc {
-    font-size: 0.85rem;
-    color: var(--color-text-secondary, #9ca3af);
+    font-size: $text-sm;
+    color: $text-secondary;
     max-width: 340px;
     margin: 0 auto;
     line-height: 1.5;
@@ -69,37 +72,29 @@
 
 // Explainer card
 .explainer-card {
-  background: var(--color-surface-elevated, #1f2937);
-  border: 1px solid var(--color-border, #374151);
-  border-radius: 12px;
+  @include xomper-card;
   padding: 20px;
 
   .explainer-badge {
-    display: inline-block;
-    font-size: 0.65rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    color: var(--color-accent, #10b981);
-    border: 1px solid var(--color-accent, #10b981);
-    border-radius: 4px;
-    padding: 2px 6px;
+    @include xomper-chip-outline;
     margin-bottom: 10px;
+    font-size: 0.65rem;
   }
 
   .explainer-title {
     font-size: 1.1rem;
     font-weight: 700;
-    color: var(--color-text-primary, #f9fafb);
+    color: $text-primary;
     margin: 0 0 10px;
   }
 
   .explainer-body {
-    font-size: 0.85rem;
-    color: var(--color-text-secondary, #9ca3af);
+    font-size: $text-sm;
+    color: $text-secondary;
     line-height: 1.55;
     margin: 0 0 12px;
 
-    strong { color: var(--color-text-primary, #f9fafb); }
+    strong { color: $text-primary; }
     em { font-style: italic; }
   }
 
@@ -112,19 +107,19 @@
 
     li {
       font-size: 0.82rem;
-      color: var(--color-text-secondary, #9ca3af);
+      color: $text-secondary;
       line-height: 1.5;
 
-      strong { color: var(--color-text-primary, #f9fafb); }
+      strong { color: $text-primary; }
     }
   }
 
   .explainer-status {
     font-size: 0.78rem;
-    color: var(--color-text-tertiary, #6b7280);
+    color: $text-muted;
     margin: 0;
 
-    strong { color: var(--color-text-secondary, #9ca3af); }
+    strong { color: $text-secondary; }
   }
 }
 
@@ -136,7 +131,7 @@
 
   &.playoff-section {
     .order-row {
-      background: var(--color-surface-tinted, rgba(16, 185, 129, 0.04));
+      background: rgba($champion-gold, 0.04);
     }
   }
 }
@@ -148,15 +143,15 @@
   margin-bottom: 10px;
 
   .section-title {
-    font-size: 0.95rem;
+    font-size: $text-sm;
     font-weight: 700;
-    color: var(--color-text-primary, #f9fafb);
+    color: $text-primary;
     margin: 0;
   }
 
   .section-subtitle {
-    font-size: 0.72rem;
-    color: var(--color-text-tertiary, #6b7280);
+    font-size: $text-xs;
+    color: $text-muted;
   }
 }
 
@@ -171,9 +166,9 @@ $cols: 36px 1fr 72px 72px 80px;
   font-size: 0.7rem;
   font-weight: 600;
   letter-spacing: 0.04em;
-  color: var(--color-text-tertiary, #6b7280);
+  color: $text-muted;
   text-transform: uppercase;
-  border-bottom: 1px solid var(--color-border, #374151);
+  border-bottom: 1px solid rgba($surface-light, 0.4);
 }
 
 .order-row {
@@ -182,12 +177,12 @@ $cols: 36px 1fr 72px 72px 80px;
   gap: 0 8px;
   align-items: center;
   padding: 10px 12px;
-  border-bottom: 1px solid var(--color-border-subtle, #1f2937);
+  border-bottom: 1px solid rgba($surface-light, 0.15);
 
   &:last-child { border-bottom: none; }
 
   &.playoff-row {
-    border-left: 2px solid var(--color-accent, #10b981);
+    border-left: 2px solid $champion-gold;
   }
 }
 
@@ -196,9 +191,9 @@ $cols: 36px 1fr 72px 72px 80px;
 }
 
 .pick-number {
-  font-size: 0.9rem;
+  font-size: $text-sm;
   font-weight: 700;
-  color: var(--color-text-secondary, #9ca3af);
+  color: $text-secondary;
 }
 
 .team-cell {
@@ -210,28 +205,23 @@ $cols: 36px 1fr 72px 72px 80px;
   .team-name {
     font-size: 0.87rem;
     font-weight: 600;
-    color: var(--color-text-primary, #f9fafb);
+    color: $text-primary;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   .user-name {
-    font-size: 0.72rem;
-    color: var(--color-text-tertiary, #6b7280);
+    font-size: $text-xs;
+    color: $text-muted;
   }
 
   .playoff-badge {
-    display: inline-block;
+    @include xomper-chip-outline;
     font-size: 0.6rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    color: var(--color-accent, #10b981);
-    border: 1px solid var(--color-accent, #10b981);
-    border-radius: 3px;
-    padding: 1px 4px;
     margin-top: 2px;
     width: fit-content;
+    border-radius: 3px;
   }
 }
 
@@ -239,24 +229,23 @@ $cols: 36px 1fr 72px 72px 80px;
 .col-pf,
 .col-hpp {
   font-size: 0.82rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: $text-secondary;
   text-align: right;
 }
 
 .hpp-pending {
-  color: var(--color-text-tertiary, #6b7280);
+  color: $text-muted;
   font-style: italic;
 }
 
 // Disclaimer at bottom
 .hpp-disclaimer {
+  @include xomper-card;
   padding: 12px 16px;
-  background: var(--color-surface-elevated, #1f2937);
-  border-radius: 8px;
 
   p {
-    font-size: 0.72rem;
-    color: var(--color-text-tertiary, #6b7280);
+    font-size: $text-xs;
+    color: $text-muted;
     margin: 0;
     line-height: 1.5;
   }

--- a/src/app/pages/league/league.component.scss
+++ b/src/app/pages/league/league.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .league-page {
   display: flex;
@@ -12,14 +13,10 @@
 }
 
 .league-container {
-  background: $card-gradient;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba($surface-light, 0.2);
-  border-radius: $radius-lg;
+  @include xomper-hero-card;
   padding: $spacing-lg;
   width: 95%;
   max-width: 1200px;
-  box-shadow: $shadow-lg;
 }
 
 .league-header {

--- a/src/app/pages/league/matchups/matchups.component.scss
+++ b/src/app/pages/league/matchups/matchups.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 // Season Selector
 .season-selector {
@@ -11,14 +12,10 @@
 }
 
 .season-btn {
+  @include xomper-chip-outline;
   padding: 8px 20px;
   border-radius: $radius-xl;
-  border: 1px solid $surface-light;
-  background: transparent;
-  color: $text-secondary;
   font-size: $text-sm;
-  font-family: $font-body;
-  font-weight: 600;
   cursor: pointer;
   transition: all $transition-base;
 
@@ -38,8 +35,7 @@
 .empty-state {
   text-align: center;
   padding: $spacing-2xl;
-  background: rgba($dark-navy, 0.4);
-  border-radius: $radius-lg;
+  @include xomper-card;
   border: 1px solid rgba($surface-light, 0.2);
 
   p {
@@ -63,10 +59,8 @@
 }
 
 .week-section {
-  background: rgba($dark-navy, 0.4);
-  backdrop-filter: blur(10px);
+  @include xomper-card;
   border: 1px solid rgba($surface-light, 0.2);
-  border-radius: $radius-lg;
   overflow: hidden;
   transition: all $transition-base;
 

--- a/src/app/pages/league/rules/league-settings/league-settings.component.scss
+++ b/src/app/pages/league/rules/league-settings/league-settings.component.scss
@@ -1,15 +1,16 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .rules-section {
   margin-bottom: $spacing-xl;
 }
 
 .rules-section-title {
+  @include xomper-subheader;
   font-family: $font-display;
   font-size: 1.5rem;
   letter-spacing: 0.05em;
-  color: $champion-gold;
   margin: 0 0 $spacing-md;
 }
 
@@ -61,13 +62,11 @@
 }
 
 .setting-card {
+  @include xomper-card;
   display: flex;
   flex-direction: column;
   gap: $spacing-xs;
   padding: $spacing-md;
-  background: rgba($dark-navy, 0.5);
-  border: 1px solid rgba($surface-light, 0.2);
-  border-radius: $radius-md;
 }
 
 .setting-label {

--- a/src/app/pages/league/rules/payouts/payouts.component.scss
+++ b/src/app/pages/league/rules/payouts/payouts.component.scss
@@ -1,15 +1,16 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .rules-section {
   margin-bottom: $spacing-xl;
 }
 
 .rules-section-title {
+  @include xomper-subheader;
   font-family: $font-display;
   font-size: 1.5rem;
   letter-spacing: 0.05em;
-  color: $champion-gold;
   margin: 0 0 $spacing-md;
 }
 

--- a/src/app/pages/league/rules/rulebook/rulebook.component.scss
+++ b/src/app/pages/league/rules/rulebook/rulebook.component.scss
@@ -1,15 +1,16 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .rules-section {
   margin-bottom: $spacing-xl;
 }
 
 .rules-section-title {
+  @include xomper-subheader;
   font-family: $font-display;
   font-size: 1.5rem;
   letter-spacing: 0.05em;
-  color: $champion-gold;
   margin: 0 0 $spacing-md;
 }
 
@@ -21,14 +22,12 @@
 }
 
 .rulebook-chapter {
-  background: rgba($dark-navy, 0.4);
-  border: 1px solid rgba($surface-light, 0.12);
-  border-radius: $radius-md;
+  @include xomper-card;
   overflow: hidden;
   transition: all $transition-base;
 
   &.expanded {
-    border-color: rgba($champion-gold, 0.3);
+    border: 1px solid rgba($champion-gold, 0.3);
   }
 }
 

--- a/src/app/pages/league/rules/scoring/scoring.component.scss
+++ b/src/app/pages/league/rules/scoring/scoring.component.scss
@@ -1,15 +1,16 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .rules-section {
   margin-bottom: $spacing-xl;
 }
 
 .rules-section-title {
+  @include xomper-subheader;
   font-family: $font-display;
   font-size: 1.5rem;
   letter-spacing: 0.05em;
-  color: $champion-gold;
   margin: 0 0 $spacing-md;
 }
 
@@ -21,9 +22,7 @@
 }
 
 .scoring-category {
-  background: rgba($dark-navy, 0.5);
-  border: 1px solid rgba($surface-light, 0.2);
-  border-radius: $radius-lg;
+  @include xomper-card;
   overflow: hidden;
 }
 

--- a/src/app/pages/league/standings/standings.component.scss
+++ b/src/app/pages/league/standings/standings.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 // View Toggle Buttons
 .switch-container {
@@ -14,15 +15,10 @@
 }
 
 .view-button {
-  background-color: rgba($dark-navy, 0.6);
-  color: $text-secondary;
-  border: 1px solid $surface-light;
-  border-radius: $radius-xl;
+  @include xomper-chip-outline;
   padding: 10px 24px;
-  margin: 0;
-  cursor: pointer;
   font-size: $text-sm;
-  font-family: $font-body;
+  cursor: pointer;
   transition: all $transition-base;
 
   &:hover:not(.selected) {
@@ -95,10 +91,10 @@
       text-shadow: 0 0 10px rgba($champion-gold, 0.5);
     }
     &.silver {
-      color: silver;
+      color: #b0bec5;
     }
     &.bronze {
-      color: #cd7f32;
+      color: #8d6e63;
     }
   }
 }
@@ -147,8 +143,8 @@
 }
 
 .team-more-btn {
-  background: $steel-blue;
-  color: white;
+  background: $champion-gold;
+  color: $deep-navy;
   border: none;
   border-radius: $radius-xl;
   padding: 6px 16px;
@@ -159,7 +155,7 @@
   transition: all $transition-base;
 
   &:hover {
-    background-color: darken($steel-blue, 10%);
+    filter: brightness(1.1);
     transform: scale(1.05);
   }
 }

--- a/src/app/pages/link-sleeper/link-sleeper.component.scss
+++ b/src/app/pages/link-sleeper/link-sleeper.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .link-page {
   min-height: 100vh;
@@ -11,14 +12,10 @@
 }
 
 .link-card {
-  background: $card-gradient;
-  backdrop-filter: blur(12px);
-  border: 1px solid rgba($champion-gold, 0.2);
-  border-radius: $radius-lg;
+  @include xomper-hero-card;
   padding: $spacing-xl;
   width: 100%;
   max-width: 420px;
-  box-shadow: $shadow-xl;
 }
 
 // ==========================================
@@ -93,7 +90,7 @@
   padding: 14px $spacing-lg;
   border-radius: $radius-xl;
   border: none;
-  background: $gold-accent;
+  background: $champion-gold;
   color: $deep-navy;
   font-size: $text-base;
   font-weight: 600;
@@ -199,7 +196,7 @@
   margin: 0;
 
   &.yes {
-    background: $gold-accent;
+    background: $champion-gold;
     color: $deep-navy;
 
     &:hover:not(:disabled) {

--- a/src/app/pages/login/login.component.scss
+++ b/src/app/pages/login/login.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .login-page {
   display: flex;
@@ -86,13 +87,10 @@
 
 // Login Box
 .login-box {
-  background: $card-gradient;
-  backdrop-filter: blur(12px);
-  border: 1px solid rgba($champion-gold, 0.2);
-  border-radius: $radius-lg;
+  @include xomper-hero-card;
   padding: $spacing-xl;
   width: 100%;
-  box-shadow: $shadow-xl;
+  border: 1px solid rgba($champion-gold, 0.2);
 }
 
 .login-title {
@@ -221,7 +219,7 @@
 }
 
 .auth-error {
-  color: #ef4444;
+  color: $error-red;
   font-size: $text-sm;
   text-align: center;
   margin: 0;

--- a/src/app/pages/matchup-history/matchup-history.component.scss
+++ b/src/app/pages/matchup-history/matchup-history.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .matchup-history-page {
   min-height: 100vh;
@@ -98,11 +99,9 @@
 
 // Empty State
 .empty-state {
+  @include xomper-card;
   text-align: center;
   padding: $spacing-2xl;
-  background: $card-gradient;
-  border-radius: $radius-lg;
-  border: 1px solid rgba($surface-light, 0.2);
 
   p {
     font-size: $text-lg;
@@ -125,10 +124,7 @@
 }
 
 .week-section {
-  background: $card-gradient;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba($surface-light, 0.2);
-  border-radius: $radius-lg;
+  @include xomper-card;
   overflow: hidden;
   transition: all $transition-base;
 

--- a/src/app/pages/profile/profile.component.scss
+++ b/src/app/pages/profile/profile.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .profile-page {
   display: flex;
@@ -12,16 +13,12 @@
 }
 
 .profile-container {
+  @include xomper-card;
   text-align: center;
-  background: $card-gradient;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba($surface-light, 0.2);
-  border-radius: $radius-lg;
   padding: $spacing-xl;
   width: 450px;
   max-width: 95vw;
   min-height: 500px;
-  box-shadow: $shadow-xl;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -70,20 +67,16 @@
 }
 
 .league-card {
+  @include xomper-card;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: rgba($dark-navy, 0.6);
-  border: 1px solid rgba($surface-light, 0.3);
-  border-radius: $radius-lg;
   padding: $spacing-md;
-  box-shadow: $shadow-sm;
   transition: all $transition-base;
 
   &:hover {
     transform: translateX(4px);
     border-color: rgba($champion-gold, 0.4);
-    box-shadow: $shadow-md;
   }
 }
 
@@ -110,8 +103,8 @@
 }
 
 .league-more-btn {
-  background: $steel-blue;
-  color: white;
+  background: $champion-gold;
+  color: $deep-navy;
   border: none;
   border-radius: $radius-xl;
   padding: 8px 18px;
@@ -122,7 +115,7 @@
   transition: all $transition-base;
 
   &:hover {
-    background-color: darken($steel-blue, 10%);
+    filter: brightness(1.1);
     transform: scale(1.05);
   }
 }

--- a/src/app/pages/search/search.component.scss
+++ b/src/app/pages/search/search.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .search-page {
   display: flex;
@@ -22,12 +23,8 @@
 }
 
 .search-box {
-  background: $card-gradient;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba($surface-light, 0.2);
-  border-radius: $radius-lg;
+  @include xomper-card;
   padding: $spacing-xl $spacing-lg;
-  box-shadow: $shadow-xl;
   width: 460px;
   max-width: 90vw;
 }
@@ -59,7 +56,7 @@
   }
 
   &.active {
-    background: $gold-accent;
+    background: $champion-gold;
     color: $deep-navy;
     border-color: $champion-gold;
   }
@@ -97,7 +94,7 @@
   padding: 14px 24px;
   border-radius: $radius-xl;
   border: none;
-  background: $gold-accent;
+  background: $champion-gold;
   color: $deep-navy;
   font-size: $text-sm;
   font-weight: 700;

--- a/src/app/pages/settings/settings.component.scss
+++ b/src/app/pages/settings/settings.component.scss
@@ -1,4 +1,6 @@
 @import 'src/styles/variables';
+@import 'src/styles/mixins';
+@import 'src/styles/theme';
 
 .settings-page {
   display: flex;
@@ -9,9 +11,7 @@
 }
 
 .settings-card {
-  background: var(--xomper-bg-card, $bg-card);
-  border: 1px solid $surface-light;
-  border-radius: $radius-lg;
+  @include xomper-card;
   padding: $spacing-2xl;
   text-align: center;
   max-width: 400px;
@@ -20,19 +20,19 @@
   &__title {
     font-family: $font-display;
     font-size: $text-3xl;
-    color: var(--xomper-champion-gold, $champion-gold);
+    color: $champion-gold;
     margin-bottom: $spacing-md;
   }
 
   &__body {
-    color: var(--xomper-text-muted, $text-muted);
+    color: $text-muted;
     font-size: $text-base;
     margin-bottom: $spacing-xl;
   }
 
   &__back {
     display: inline-block;
-    color: var(--xomper-champion-gold, $champion-gold);
+    color: $champion-gold;
     text-decoration: none;
     font-size: $text-sm;
     font-weight: 600;

--- a/src/app/pages/taxi-squad/taxi-squad.component.scss
+++ b/src/app/pages/taxi-squad/taxi-squad.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .taxi-page {
   display: flex;
@@ -52,7 +53,7 @@
     transition: all $transition-base;
 
     &.active {
-      background: $gold-accent;
+      background: $champion-gold;
       color: $deep-navy;
       border-color: $champion-gold;
       font-weight: 600;
@@ -234,12 +235,12 @@
 // Clickable
 .clickable {
   cursor: pointer;
-  color: $steel-blue;
+  color: $text-secondary;
   text-decoration: none;
   transition: color $transition-fast;
 
   &:hover {
-    color: lighten($steel-blue, 15%);
+    color: $champion-gold;
     text-decoration: underline;
   }
 }

--- a/src/app/pages/team-analyzer/hexagon-chart/hexagon-chart.component.scss
+++ b/src/app/pages/team-analyzer/hexagon-chart/hexagon-chart.component.scss
@@ -1,4 +1,5 @@
-@use '../../../../styles/variables' as v;
+@import '../../../../styles/variables';
+@import '../../../../styles/mixins';
 
 .hexagon-chart {
   display: block;
@@ -10,7 +11,7 @@
 
 // Grid rings
 .grid-ring {
-  stroke: rgba(v.$surface-light, 0.35);
+  stroke: rgba($surface-light, 0.35);
   stroke-width: 1;
 
   &--outer {
@@ -20,7 +21,7 @@
 
 // Axis lines
 .axis-line {
-  stroke: rgba(v.$surface-light, 0.25);
+  stroke: rgba($surface-light, 0.25);
   stroke-width: 1;
   fill: none;
 }
@@ -28,8 +29,8 @@
 // Polygons — primary (gold)
 .polygon {
   &--primary {
-    fill: rgba(v.$champion-gold, 0.28);
-    stroke: v.$champion-gold;
+    fill: rgba($champion-gold, 0.28);
+    stroke: $champion-gold;
     stroke-width: 2;
   }
 
@@ -52,7 +53,7 @@
 // Vertex dots
 .dot {
   &--primary {
-    fill: v.$champion-gold;
+    fill: $champion-gold;
   }
 
   &--comparison {
@@ -62,10 +63,10 @@
 
 // Axis labels
 .axis-label {
-  font-family: v.$font-body;
+  font-family: $font-body;
   font-size: 11px;
   font-weight: 700;
-  fill: v.$text-secondary;
+  fill: $text-secondary;
   letter-spacing: 0.02em;
   user-select: none;
 }

--- a/src/app/pages/team-analyzer/position-breakdown-card/position-breakdown-card.component.scss
+++ b/src/app/pages/team-analyzer/position-breakdown-card/position-breakdown-card.component.scss
@@ -1,25 +1,26 @@
-@use '../../../../styles/variables' as v;
+@import '../../../../styles/variables';
+@import '../../../../styles/mixins';
+@import '../../../../styles/theme';
 
 .breakdown-card {
-  background: v.$bg-card;
-  border-radius: v.$radius-lg;
-  padding: v.$spacing-md;
+  @include xomper-card;
+  padding: $spacing-md;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xs;
-  margin: 0 v.$spacing-md;
+  gap: $spacing-xs;
+  margin: 0 $spacing-md;
 }
 
 .breakdown-row {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: $spacing-sm;
 }
 
 .label {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 600;
-  color: v.$text-primary;
+  color: $text-primary;
   width: 52px;
   flex-shrink: 0;
 }
@@ -27,36 +28,36 @@
 .bar-track {
   flex: 1;
   height: 6px;
-  background: rgba(v.$surface-light, 0.4);
-  border-radius: v.$radius-sm;
+  background: rgba($surface-light, 0.4);
+  border-radius: $radius-sm;
   overflow: hidden;
 }
 
 .bar-fill {
   height: 100%;
-  background: v.$champion-gold;
-  border-radius: v.$radius-sm;
-  transition: width v.$transition-base;
+  background: $champion-gold;
+  border-radius: $radius-sm;
+  transition: width $transition-base;
 }
 
 .value {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 700;
-  font-family: v.$font-mono;
+  font-family: $font-mono;
   width: 48px;
   text-align: right;
   flex-shrink: 0;
 }
 
 .my-value {
-  color: v.$text-primary;
+  color: $text-primary;
 
   &.delta--gold {
-    color: v.$champion-gold;
+    color: $champion-gold;
   }
 
   &.delta--red {
-    color: v.$error-red;
+    color: $error-red;
   }
 }
 
@@ -65,37 +66,37 @@
 }
 
 .avg-value {
-  color: v.$text-muted;
+  color: $text-muted;
 }
 
 .divider {
   height: 1px;
-  background: rgba(v.$surface-light, 0.4);
-  margin: v.$spacing-xs 0;
+  background: rgba($surface-light, 0.4);
+  margin: $spacing-xs 0;
 }
 
 .total-row {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: $spacing-sm;
 }
 
 .total-label {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 600;
-  color: v.$text-secondary;
+  color: $text-secondary;
   flex: 1;
 }
 
 .total-my {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$champion-gold;
-  font-family: v.$font-mono;
+  color: $champion-gold;
+  font-family: $font-mono;
 }
 
 .total-opp {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   color: #00ffff;
-  font-family: v.$font-mono;
+  font-family: $font-mono;
 }

--- a/src/app/pages/team-analyzer/recommended-trade-card/recommended-trade-card.component.scss
+++ b/src/app/pages/team-analyzer/recommended-trade-card/recommended-trade-card.component.scss
@@ -1,18 +1,20 @@
-@use '../../../../styles/variables' as v;
+@import '../../../../styles/variables';
+@import '../../../../styles/mixins';
+@import '../../../../styles/theme';
 
 .rec-card {
-  background: v.$bg-card;
-  border-radius: v.$radius-lg;
-  border: 1px solid rgba(v.$champion-gold, 0.3);
-  padding: v.$spacing-md;
+  @include xomper-card;
+  border: 1px solid rgba($champion-gold, 0.3);
+  padding: $spacing-md;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xs;
+  gap: $spacing-xs;
   cursor: pointer;
-  transition: background v.$transition-fast;
+  transition: background $transition-fast, border-color $transition-fast;
 
   &:hover {
-    background: v.$bg-card-hover;
+    background: $bg-card-hover;
+    border-color: rgba($champion-gold, 0.5);
   }
 }
 
@@ -20,25 +22,25 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: v.$spacing-sm;
+  gap: $spacing-sm;
 }
 
 .partner-name {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$text-primary;
+  color: $text-primary;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .gap-pill {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 700;
-  color: v.$bg-dark;
-  background: v.$success-green;
-  padding: 2px v.$spacing-xs;
-  border-radius: v.$radius-full;
+  color: $bg-dark;
+  background: $success-green;
+  padding: 2px $spacing-xs;
+  border-radius: $radius-full;
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -46,8 +48,8 @@
 .rec-sides {
   display: flex;
   align-items: flex-start;
-  gap: v.$spacing-sm;
-  margin-top: v.$spacing-xs;
+  gap: $spacing-sm;
+  margin-top: $spacing-xs;
 }
 
 .rec-side {
@@ -58,45 +60,45 @@
 }
 
 .side-label {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
 
   &.give-label {
-    color: v.$text-muted;
+    color: $text-muted;
   }
 
   &.receive-label {
-    color: v.$champion-gold;
+    color: $champion-gold;
   }
 }
 
 .player-name {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 600;
-  color: v.$text-primary;
+  color: $text-primary;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .player-meta {
-  font-size: v.$text-xs;
-  color: v.$text-muted;
-  font-family: v.$font-mono;
+  font-size: $text-xs;
+  color: $text-muted;
+  font-family: $font-mono;
 }
 
 .arrows {
-  font-size: v.$text-lg;
-  color: v.$text-muted;
+  font-size: $text-lg;
+  color: $text-muted;
   align-self: center;
   flex-shrink: 0;
-  margin-top: v.$spacing-md;
+  margin-top: $spacing-md;
 }
 
 .tap-hint {
-  font-size: v.$text-xs;
-  color: v.$text-muted;
-  margin-top: v.$spacing-xs;
+  font-size: $text-xs;
+  color: $text-muted;
+  margin-top: $spacing-xs;
 }

--- a/src/app/pages/team-analyzer/team-analyzer.component.scss
+++ b/src/app/pages/team-analyzer/team-analyzer.component.scss
@@ -1,10 +1,12 @@
-@use '../../../styles/variables' as v;
+@import '../../../styles/variables';
+@import '../../../styles/mixins';
+@import '../../../styles/theme';
 
 // Page shell
 .analyzer-page {
-  background: v.$bg-dark;
+  background: $bg-dark;
   min-height: 100%;
-  padding-bottom: v.$spacing-xl;
+  padding-bottom: $spacing-xl;
   position: relative;
 }
 
@@ -16,27 +18,27 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: v.$spacing-xl v.$spacing-md;
-  gap: v.$spacing-md;
+  padding: $spacing-xl $spacing-md;
+  gap: $spacing-md;
 }
 
 .state-msg {
-  font-size: v.$text-sm;
-  color: v.$text-secondary;
+  font-size: $text-sm;
+  color: $text-secondary;
   text-align: center;
 
   &--error {
-    color: v.$error-red;
+    color: $error-red;
   }
 }
 
 .retry-btn {
-  background: v.$champion-gold;
-  color: v.$bg-dark;
+  background: $champion-gold;
+  color: $bg-dark;
   border: none;
-  border-radius: v.$radius-full;
-  padding: v.$spacing-xs v.$spacing-md;
-  font-size: v.$text-sm;
+  border-radius: $radius-full;
+  padding: $spacing-xs $spacing-md;
+  font-size: $text-sm;
   font-weight: 700;
   cursor: pointer;
 }
@@ -46,9 +48,9 @@
 // ────────────────────────────────────────────────────────
 .tab-bar {
   display: flex;
-  background: v.$bg-dark;
-  border-bottom: 1px solid rgba(v.$surface-light, 0.3);
-  padding-top: v.$spacing-xs;
+  background: $bg-dark;
+  border-bottom: 1px solid rgba($surface-light, 0.3);
+  padding-top: $spacing-xs;
 }
 
 .tab-btn {
@@ -57,18 +59,18 @@
   flex-direction: column;
   align-items: center;
   gap: 4px;
-  padding: v.$spacing-xs v.$spacing-sm v.$spacing-xs;
+  padding: $spacing-xs $spacing-sm $spacing-xs;
   background: none;
   border: none;
   cursor: pointer;
-  color: v.$text-secondary;
-  font-size: v.$text-sm;
+  color: $text-secondary;
+  font-size: $text-sm;
   font-weight: 400;
-  font-family: v.$font-body;
-  transition: color v.$transition-fast;
+  font-family: $font-body;
+  transition: color $transition-fast;
 
   &--active {
-    color: v.$champion-gold;
+    color: $champion-gold;
     font-weight: 700;
   }
 }
@@ -77,10 +79,10 @@
   height: 2px;
   width: 100%;
   background: transparent;
-  transition: background v.$transition-fast;
+  transition: background $transition-fast;
 
   &--visible {
-    background: v.$champion-gold;
+    background: $champion-gold;
   }
 }
 
@@ -90,34 +92,34 @@
 .tab-content {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-md;
-  padding: v.$spacing-md 0;
+  gap: $spacing-md;
+  padding: $spacing-md 0;
 }
 
 // ────────────────────────────────────────────────────────
 // Shared text helpers
 // ────────────────────────────────────────────────────────
 .caption {
-  font-size: v.$text-sm;
-  color: v.$text-secondary;
-  padding: 0 v.$spacing-md;
+  font-size: $text-sm;
+  color: $text-secondary;
+  padding: 0 $spacing-md;
 }
 
 .section-label {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 600;
-  color: v.$text-secondary;
+  color: $text-secondary;
   flex-shrink: 0;
 }
 
 .section-eyebrow {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: v.$text-muted;
-  padding: 0 v.$spacing-md;
-  margin-top: v.$spacing-xs;
+  color: $text-muted;
+  padding: 0 $spacing-md;
+  margin-top: $spacing-xs;
 }
 
 .spacer {
@@ -130,18 +132,18 @@
 .legend {
   display: flex;
   align-items: center;
-  gap: v.$spacing-md;
+  gap: $spacing-md;
   flex-wrap: wrap;
-  padding: 0 v.$spacing-md;
+  padding: 0 $spacing-md;
 }
 
 .legend-chip {
   display: flex;
   align-items: center;
-  gap: v.$spacing-xs;
-  font-size: v.$text-xs;
+  gap: $spacing-xs;
+  font-size: $text-xs;
   font-weight: 500;
-  color: v.$text-primary;
+  color: $text-primary;
 
   &::before {
     content: '';
@@ -152,7 +154,7 @@
   }
 
   &--gold::before {
-    background: v.$champion-gold;
+    background: $champion-gold;
   }
 
   &--cyan::before {
@@ -171,26 +173,26 @@
 .opponent-row {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
-  padding: 0 v.$spacing-md;
+  gap: $spacing-sm;
+  padding: 0 $spacing-md;
 }
 
 .dropdown {
-  background: rgba(v.$surface-light, 0.4);
-  border: 1px solid rgba(v.$surface-light, 0.6);
-  border-radius: v.$radius-xl;
-  color: v.$text-primary;
-  font-size: v.$text-sm;
+  background: rgba($surface-light, 0.4);
+  border: 1px solid rgba($surface-light, 0.6);
+  border-radius: $radius-xl;
+  color: $text-primary;
+  font-size: $text-sm;
   font-weight: 600;
-  font-family: v.$font-body;
-  padding: v.$spacing-xs v.$spacing-md;
+  font-family: $font-body;
+  padding: $spacing-xs $spacing-md;
   cursor: pointer;
   outline: none;
   max-width: 240px;
 
   option {
-    background: v.$bg-card;
-    color: v.$text-primary;
+    background: $bg-card;
+    color: $text-primary;
   }
 }
 
@@ -198,23 +200,22 @@
 // League averages card
 // ────────────────────────────────────────────────────────
 .avg-card {
-  margin: 0 v.$spacing-md;
-  padding: v.$spacing-md;
-  background: v.$bg-card;
-  border-radius: v.$radius-lg;
-  border: 1px solid rgba(v.$champion-gold, 0.3);
+  @include xomper-card;
+  margin: 0 $spacing-md;
+  padding: $spacing-md;
+  border: 1px solid rgba($champion-gold, 0.3);
 }
 
 .avg-card-title {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$champion-gold;
-  margin-bottom: v.$spacing-sm;
+  color: $champion-gold;
+  margin-bottom: $spacing-sm;
 }
 
 .avg-axes {
   display: flex;
-  gap: v.$spacing-md;
+  gap: $spacing-md;
   flex-wrap: wrap;
 }
 
@@ -227,23 +228,23 @@
 }
 
 .avg-axis-label {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 600;
-  color: v.$text-muted;
+  color: $text-muted;
   text-transform: uppercase;
 }
 
 .avg-axis-value {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$text-primary;
-  font-family: v.$font-mono;
+  color: $text-primary;
+  font-family: $font-mono;
 }
 
 .avg-divider {
   height: 1px;
-  background: rgba(v.$surface-light, 0.4);
-  margin: v.$spacing-sm 0;
+  background: rgba($surface-light, 0.4);
+  margin: $spacing-sm 0;
 }
 
 .avg-total-row {
@@ -252,92 +253,87 @@
 }
 
 .avg-total-label {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 600;
-  color: v.$text-secondary;
+  color: $text-secondary;
   flex: 1;
 }
 
 .avg-total-value {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$champion-gold;
-  font-family: v.$font-mono;
+  color: $champion-gold;
+  font-family: $font-mono;
 }
 
 // ────────────────────────────────────────────────────────
 // League team rows
 // ────────────────────────────────────────────────────────
 .league-row {
-  margin: 0 v.$spacing-md;
-  padding: v.$spacing-md;
-  background: v.$bg-card;
-  border-radius: v.$radius-lg;
+  @include xomper-card;
+  margin: 0 $spacing-md;
+  padding: $spacing-md;
   border: 1px solid transparent;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xs;
+  gap: $spacing-xs;
 
   &--mine {
-    border-color: rgba(v.$champion-gold, 0.4);
+    border-color: rgba($champion-gold, 0.4);
   }
 }
 
 .league-row-header {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: $spacing-sm;
 }
 
 .rank {
-  font-size: v.$text-lg;
+  font-size: $text-lg;
   font-weight: 700;
-  color: v.$text-secondary;
-  font-family: v.$font-mono;
+  color: $text-secondary;
+  font-family: $font-mono;
   width: 28px;
   flex-shrink: 0;
 
   &--first {
-    color: v.$champion-gold;
+    color: $champion-gold;
   }
 }
 
 .team-name {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 600;
-  color: v.$text-primary;
+  color: $text-primary;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 
   &--mine {
-    color: v.$champion-gold;
+    color: $champion-gold;
     font-weight: 700;
   }
 }
 
 .you-badge {
-  font-size: v.$text-xs;
-  font-weight: 700;
-  color: v.$bg-dark;
-  background: v.$champion-gold;
-  padding: 2px v.$spacing-xs;
-  border-radius: v.$radius-full;
+  @include xomper-chip;
+  padding: 2px $spacing-xs;
   flex-shrink: 0;
 }
 
 .total-val {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$text-primary;
-  font-family: v.$font-mono;
+  color: $text-primary;
+  font-family: $font-mono;
   flex-shrink: 0;
 }
 
 // Per-axis bars in league tab
 .axis-bars {
   display: flex;
-  gap: v.$spacing-xs;
+  gap: $spacing-xs;
 }
 
 .axis-bar-col {
@@ -351,91 +347,89 @@
 .axis-bar-label {
   font-size: 10px;
   font-weight: 600;
-  color: v.$text-muted;
+  color: $text-muted;
   text-transform: uppercase;
   text-align: center;
 }
 
 .axis-bar-track {
   height: 6px;
-  background: rgba(v.$surface-light, 0.4);
-  border-radius: v.$radius-sm;
+  background: rgba($surface-light, 0.4);
+  border-radius: $radius-sm;
   overflow: hidden;
 }
 
 .axis-bar-fill {
   height: 100%;
-  background: v.$text-primary;
-  border-radius: v.$radius-sm;
-  transition: width v.$transition-base;
+  background: $text-primary;
+  border-radius: $radius-sm;
+  transition: width $transition-base;
 
-  &.delta--gold { background: v.$champion-gold; }
-  &.delta--red  { background: v.$error-red; }
+  &.delta--gold { background: $champion-gold; }
+  &.delta--red  { background: $error-red; }
 }
 
 .axis-bar-val {
   font-size: 10px;
   font-weight: 700;
-  color: v.$text-primary;
-  font-family: v.$font-mono;
+  color: $text-primary;
+  font-family: $font-mono;
   text-align: center;
 
-  &.delta--gold { color: v.$champion-gold; }
-  &.delta--red  { color: v.$error-red; }
+  &.delta--gold { color: $champion-gold; }
+  &.delta--red  { color: $error-red; }
 }
 
 // ────────────────────────────────────────────────────────
 // Trade tab
 // ────────────────────────────────────────────────────────
 .explainer-card {
-  margin: 0 v.$spacing-md;
-  padding: v.$spacing-md;
-  background: v.$bg-card;
-  border-radius: v.$radius-lg;
-  border: 1px solid rgba(v.$champion-gold, 0.3);
+  @include xomper-card;
+  margin: 0 $spacing-md;
+  padding: $spacing-md;
+  border: 1px solid rgba($champion-gold, 0.3);
 }
 
 .explainer-header {
   display: flex;
   align-items: center;
-  gap: v.$spacing-xs;
-  margin-bottom: v.$spacing-xs;
+  gap: $spacing-xs;
+  margin-bottom: $spacing-xs;
 }
 
 .explainer-icon {
-  color: v.$champion-gold;
-  font-size: v.$text-lg;
+  color: $champion-gold;
+  font-size: $text-lg;
 }
 
 .explainer-title {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$champion-gold;
+  color: $champion-gold;
 }
 
 .explainer-body {
-  font-size: v.$text-xs;
-  color: v.$text-secondary;
+  font-size: $text-xs;
+  color: $text-secondary;
   line-height: 1.5;
 }
 
 // Evaluation strip
 .eval-card {
-  margin: 0 v.$spacing-md;
-  padding: v.$spacing-md;
-  background: v.$bg-card;
-  border-radius: v.$radius-lg;
+  @include xomper-card;
+  margin: 0 $spacing-md;
+  padding: $spacing-md;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: $spacing-sm;
 }
 
 .eval-values {
   display: flex;
   align-items: center;
   width: 100%;
-  gap: v.$spacing-md;
+  gap: $spacing-md;
 }
 
 .eval-col {
@@ -447,58 +441,57 @@
 }
 
 .eval-col-label {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 600;
-  color: v.$text-muted;
+  color: $text-muted;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
 .eval-col-val {
-  font-size: v.$text-xl;
+  font-size: $text-xl;
   font-weight: 700;
-  color: v.$champion-gold;
-  font-family: v.$font-mono;
+  color: $champion-gold;
+  font-family: $font-mono;
 }
 
 .eval-arrow {
-  font-size: v.$text-xl;
-  color: v.$text-muted;
+  font-size: $text-xl;
+  color: $text-muted;
 }
 
 .verdict-pill {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  padding: v.$spacing-xs v.$spacing-md;
-  border-radius: v.$radius-full;
+  padding: $spacing-xs $spacing-md;
+  border-radius: $radius-full;
 
   &.verdict--empty {
-    background: rgba(v.$surface-light, 0.4);
-    color: v.$text-secondary;
+    background: rgba($surface-light, 0.4);
+    color: $text-secondary;
   }
 
   &.verdict--fair {
-    background: v.$success-green;
-    color: v.$bg-dark;
+    background: $success-green;
+    color: $bg-dark;
   }
 
   &.verdict--uneven {
-    background: rgba(v.$error-red, 0.85);
+    background: rgba($error-red, 0.85);
     color: #fff;
   }
 }
 
 // Trade side cards
 .side-card {
-  margin: 0 v.$spacing-md;
-  padding: v.$spacing-md;
-  background: v.$bg-card;
-  border-radius: v.$radius-lg;
+  @include xomper-card;
+  margin: 0 $spacing-md;
+  padding: $spacing-md;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: $spacing-sm;
 }
 
 .side-header {
@@ -514,44 +507,44 @@
 }
 
 .side-direction {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 600;
-  color: v.$text-muted;
+  color: $text-muted;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
 .side-team {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$text-primary;
+  color: $text-primary;
 }
 
 .side-val {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$champion-gold;
-  font-family: v.$font-mono;
+  color: $champion-gold;
+  font-family: $font-mono;
 }
 
 .side-empty {
-  font-size: v.$text-xs;
-  color: v.$text-muted;
-  padding: v.$spacing-xs 0;
+  font-size: $text-xs;
+  color: $text-muted;
+  padding: $spacing-xs 0;
 }
 
 // Trade items (player / pick row)
 .trade-item {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: $spacing-sm;
   padding: 2px 0;
 }
 
 .trade-item-name {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 600;
-  color: v.$text-primary;
+  color: $text-primary;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -559,76 +552,74 @@
 }
 
 .trade-item-badge {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 700;
-  color: v.$text-secondary;
-  background: rgba(v.$surface-light, 0.4);
-  padding: 2px v.$spacing-xs;
-  border-radius: v.$radius-full;
+  color: $text-secondary;
+  background: rgba($surface-light, 0.4);
+  padding: 2px $spacing-xs;
+  border-radius: $radius-full;
   flex-shrink: 0;
 }
 
 .trade-item-val {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$champion-gold;
-  font-family: v.$font-mono;
+  color: $champion-gold;
+  font-family: $font-mono;
   flex-shrink: 0;
 }
 
 .remove-btn {
   background: none;
   border: none;
-  color: v.$text-muted;
-  font-size: v.$text-sm;
+  color: $text-muted;
+  font-size: $text-sm;
   cursor: pointer;
   padding: 2px;
   line-height: 1;
   flex-shrink: 0;
 
   &:hover {
-    color: v.$error-red;
+    color: $error-red;
   }
 }
 
 // Side add buttons
 .side-actions {
   display: flex;
-  gap: v.$spacing-xs;
+  gap: $spacing-xs;
 }
 
 .add-btn {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 700;
-  font-family: v.$font-body;
-  padding: v.$spacing-xs v.$spacing-md;
-  border-radius: v.$radius-full;
+  font-family: $font-body;
+  padding: $spacing-xs $spacing-md;
+  border-radius: $radius-full;
   cursor: pointer;
   border: none;
   min-height: 36px;
 
   &--primary {
-    background: v.$champion-gold;
-    color: v.$bg-dark;
+    background: $champion-gold;
+    color: $bg-dark;
   }
 
   &--outline {
-    background: rgba(v.$surface-light, 0.4);
-    color: v.$champion-gold;
-    border: 1px solid rgba(v.$champion-gold, 0.5);
+    background: rgba($surface-light, 0.4);
+    color: $champion-gold;
+    border: 1px solid rgba($champion-gold, 0.5);
   }
 }
 
 // Balance suggestions card
 .balance-card {
-  margin: 0 v.$spacing-md;
-  padding: v.$spacing-md;
-  background: v.$bg-card;
-  border-radius: v.$radius-lg;
-  border: 1px solid rgba(v.$champion-gold, 0.4);
+  @include xomper-hero-card;
+  margin: 0 $spacing-md;
+  padding: $spacing-md;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-sm;
+  gap: $spacing-sm;
 }
 
 .balance-header {
@@ -638,20 +629,20 @@
 }
 
 .balance-title {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$champion-gold;
+  color: $champion-gold;
 }
 
 .balance-subtitle {
-  font-size: v.$text-xs;
-  color: v.$text-muted;
+  font-size: $text-xs;
+  color: $text-muted;
 }
 
 .balance-item {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
+  gap: $spacing-sm;
   padding: 4px 0;
   background: none;
   border: none;
@@ -660,7 +651,7 @@
   text-align: left;
 
   &:hover .balance-item-name {
-    color: v.$champion-gold;
+    color: $champion-gold;
   }
 }
 
@@ -671,28 +662,28 @@
 }
 
 .balance-item-name {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 600;
-  color: v.$text-primary;
-  transition: color v.$transition-fast;
+  color: $text-primary;
+  transition: color $transition-fast;
 }
 
 .balance-item-pos {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 700;
-  color: v.$text-secondary;
+  color: $text-secondary;
 }
 
 .balance-item-val {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$champion-gold;
-  font-family: v.$font-mono;
+  color: $champion-gold;
+  font-family: $font-mono;
 }
 
 .balance-item-plus {
-  color: v.$champion-gold;
-  font-size: v.$text-lg;
+  color: $champion-gold;
+  font-size: $text-lg;
   font-weight: 700;
 }
 
@@ -702,11 +693,11 @@
   margin: 0 auto;
   background: none;
   border: none;
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 600;
-  color: v.$error-red;
+  color: $error-red;
   cursor: pointer;
-  padding: v.$spacing-sm v.$spacing-md;
+  padding: $spacing-sm $spacing-md;
 
   &:hover {
     text-decoration: underline;
@@ -717,14 +708,14 @@
 .recs-section {
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xs;
-  padding: 0 v.$spacing-md;
-  margin-top: v.$spacing-xs;
+  gap: $spacing-xs;
+  padding: 0 $spacing-md;
+  margin-top: $spacing-xs;
 }
 
 .recs-empty {
-  font-size: v.$text-xs;
-  color: v.$text-muted;
+  font-size: $text-xs;
+  color: $text-muted;
   line-height: 1.5;
 }
 
@@ -735,7 +726,7 @@
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
-  z-index: v.$z-modal-backdrop;
+  z-index: $z-modal-backdrop;
 }
 
 .picker-modal {
@@ -745,10 +736,10 @@
   transform: translateX(-50%);
   width: min(480px, 100vw);
   max-height: 80vh;
-  background: v.$bg-card;
-  border-top-left-radius: v.$radius-xl;
-  border-top-right-radius: v.$radius-xl;
-  z-index: v.$z-modal;
+  background: $bg-card;
+  border-top-left-radius: $radius-xl;
+  border-top-right-radius: $radius-xl;
+  z-index: $z-modal;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -758,15 +749,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: v.$spacing-md;
-  border-bottom: 1px solid rgba(v.$surface-light, 0.4);
+  padding: $spacing-md;
+  border-bottom: 1px solid rgba($surface-light, 0.4);
   flex-shrink: 0;
 }
 
 .picker-title {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$text-primary;
+  color: $text-primary;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -775,57 +766,57 @@
 .picker-close {
   background: none;
   border: none;
-  color: v.$text-muted;
-  font-size: v.$text-base;
+  color: $text-muted;
+  font-size: $text-base;
   cursor: pointer;
   padding: 4px;
   flex-shrink: 0;
 }
 
 .picker-note {
-  font-size: v.$text-xs;
-  color: v.$text-muted;
-  padding: v.$spacing-xs v.$spacing-md 0;
+  font-size: $text-xs;
+  color: $text-muted;
+  padding: $spacing-xs $spacing-md 0;
   flex-shrink: 0;
 }
 
 .picker-list {
   flex: 1;
   overflow-y: auto;
-  padding: v.$spacing-sm v.$spacing-md v.$spacing-md;
+  padding: $spacing-sm $spacing-md $spacing-md;
   display: flex;
   flex-direction: column;
-  gap: v.$spacing-xs;
+  gap: $spacing-xs;
 }
 
 .picker-empty {
-  font-size: v.$text-sm;
-  color: v.$text-muted;
+  font-size: $text-sm;
+  color: $text-muted;
   text-align: center;
-  padding: v.$spacing-xl 0;
+  padding: $spacing-xl 0;
 }
 
 .picker-item {
   display: flex;
   align-items: center;
-  gap: v.$spacing-sm;
-  padding: v.$spacing-md;
-  background: v.$bg-dark;
+  gap: $spacing-sm;
+  padding: $spacing-md;
+  background: $bg-dark;
   border: none;
-  border-radius: v.$radius-md;
+  border-radius: $radius-md;
   cursor: pointer;
   width: 100%;
   text-align: left;
 
   &:hover {
-    background: v.$bg-card-hover;
+    background: $bg-card-hover;
   }
 }
 
 .picker-item-name {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 600;
-  color: v.$text-primary;
+  color: $text-primary;
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -833,19 +824,19 @@
 }
 
 .picker-item-badge {
-  font-size: v.$text-xs;
+  font-size: $text-xs;
   font-weight: 700;
-  color: v.$text-secondary;
-  background: rgba(v.$surface-light, 0.4);
-  padding: 2px v.$spacing-xs;
-  border-radius: v.$radius-full;
+  color: $text-secondary;
+  background: rgba($surface-light, 0.4);
+  padding: 2px $spacing-xs;
+  border-radius: $radius-full;
   flex-shrink: 0;
 }
 
 .picker-item-val {
-  font-size: v.$text-sm;
+  font-size: $text-sm;
   font-weight: 700;
-  color: v.$champion-gold;
-  font-family: v.$font-mono;
+  color: $champion-gold;
+  font-family: $font-mono;
   flex-shrink: 0;
 }

--- a/src/app/pages/team/team.component.scss
+++ b/src/app/pages/team/team.component.scss
@@ -1,5 +1,6 @@
 @import 'styles/variables';
 @import 'styles/mixins';
+@import 'styles/theme';
 
 .team-page {
   display: flex;
@@ -21,13 +22,9 @@
 
 // Team Header
 .team-header {
-  background: $card-gradient;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba($surface-light, 0.2);
-  border-radius: $radius-lg;
+  @include xomper-card;
   padding: $spacing-lg;
   margin-bottom: $spacing-lg;
-  box-shadow: $shadow-md;
 
   .team-header-row {
     display: flex;
@@ -55,10 +52,11 @@
 
   .user-name {
     font-size: $text-base;
-    color: $steel-blue;
+    color: $text-secondary;
     cursor: pointer;
-    
+
     &:hover {
+      color: $champion-gold;
       text-decoration: underline;
     }
   }
@@ -223,12 +221,12 @@
 // Clickable elements
 .clickable {
   cursor: pointer;
-  color: $steel-blue;
+  color: $text-secondary;
   text-decoration: none;
   transition: color $transition-fast;
 
   &:hover {
-    color: lighten($steel-blue, 15%);
+    color: $champion-gold;
     text-decoration: underline;
   }
 }


### PR DESCRIPTION
## Summary

- **B3 League sub-pages** (8 files): `xomper-card`/`xomper-hero-card`/`xomper-chip-outline` applied across standings, matchups, rulebook, scoring, league-settings, payouts, draft-order; full `var(--color-*)` → `$variables` rewrite on `draft-order`
- **B4 Draft tabs** (5 files): `$gold-accent` gradient → `$champion-gold` solid on active tab/chip/pick-number
- **B6 Admin portal** (17 files): complete migration from `var(--color-surface-elevated)` / off-palette `#10b981`/`#f87171` → `$champion-gold`/`$error-red` + `xomper-card`/`xomper-chip-outline` on all sub-screens
- **B7 Team Analyzer** (4 files): `@use`→`@import` to resolve `_theme.scss` mixin conflict; `xomper-card`/`xomper-hero-card`/`xomper-chip` applied
- **B8 Misc** (15 files): search, team, profile, settings, taxi-squad, matchup-history, link-sleeper, login — card/chip treatment, `$steel-blue` clickables → `$text-secondary`; `confirm-dialog` full rewrite; modals, loader, toast theme import; `$gold-accent` → `$champion-gold` everywhere

Pure visual — zero `.ts`/`.html` changes. Build: `npm run build` PASS, zero SCSS errors.

Closes #102

## Test plan

- [ ] League: standings view-toggle chips gold-outline; draft-order explainer card styled; matchups week-sections card
- [ ] Draft: year/round tabs active state is solid gold (not gradient)
- [ ] Admin: all sub-screens use token-based backgrounds; cron toggle on = `$champion-gold`; confirm-dialog positive action = `$champion-gold`
- [ ] Team Analyzer: hexagon chart renders; balance-card has gold hero border; position breakdown card styled
- [ ] Search: mode-btn active = solid gold; search btn = solid gold
- [ ] Modals (matchup, player, taxi-squad-player): card bg applies via `xomper-hero-card`; steal-btn solid gold
- [ ] Login: hero-card border visible; error text is `$error-red`
- [ ] Link Sleeper: `.link-card` has hero-card gold border; search-btn / confirm-yes solid gold

🤖 Generated with [Claude Code](https://claude.com/claude-code)