### PR TITLE
fix(test): provide HttpClient/Router in standalone component specs — unblock Deploy Frontend

### DIFF
--- a/src/app/pages/league/matchups/matchups.component.spec.ts
+++ b/src/app/pages/league/matchups/matchups.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { LeagueHistoryService } from 'src/app/services/league-history.service';
 
 import { MatchupsComponent } from './matchups.component';
 
@@ -8,7 +12,15 @@ describe('MatchupsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MatchupsComponent]
+      imports: [MatchupsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: LeagueHistoryService,
+          useValue: { getMatchupHistoryFromChain: () => of([]), getMatchupHistory: () => of([]) },
+        },
+      ],
     })
     .compileComponents();
 

--- a/src/app/pages/league/playoffs/playoffs.component.spec.ts
+++ b/src/app/pages/league/playoffs/playoffs.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { PlayoffsComponent } from './playoffs.component';
 
@@ -8,7 +10,8 @@ describe('PlayoffsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PlayoffsComponent]
+      imports: [PlayoffsComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     })
     .compileComponents();
 

--- a/src/app/pages/league/rules/league-settings/league-settings.component.spec.ts
+++ b/src/app/pages/league/rules/league-settings/league-settings.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { LeagueSettingsComponent } from './league-settings.component';
 
@@ -8,7 +10,8 @@ describe('LeagueSettingsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [LeagueSettingsComponent]
+      imports: [LeagueSettingsComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     })
     .compileComponents();
 

--- a/src/app/pages/league/rules/rule-proposals/rule-proposals.component.spec.ts
+++ b/src/app/pages/league/rules/rule-proposals/rule-proposals.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { SupabaseService } from 'src/app/services/supabase.service';
 
 import { RuleProposalsComponent } from './rule-proposals.component';
 
@@ -8,7 +12,19 @@ describe('RuleProposalsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RuleProposalsComponent]
+      imports: [RuleProposalsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: SupabaseService,
+          useValue: {
+            currentUser$: of(null),
+            getUser: () => null,
+            getProfile: () => null,
+          },
+        },
+      ],
     })
     .compileComponents();
 

--- a/src/app/pages/league/rules/scoring/scoring.component.spec.ts
+++ b/src/app/pages/league/rules/scoring/scoring.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { ScoringComponent } from './scoring.component';
 
@@ -8,7 +10,8 @@ describe('ScoringComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ScoringComponent]
+      imports: [ScoringComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     })
     .compileComponents();
 

--- a/src/app/pages/league/standings/standings.component.spec.ts
+++ b/src/app/pages/league/standings/standings.component.spec.ts
@@ -1,4 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
 
 import { StandingsComponent } from './standings.component';
 
@@ -8,7 +11,8 @@ describe('StandingsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [StandingsComponent]
+      imports: [StandingsComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
     })
     .compileComponents();
 

--- a/src/app/pages/league/world-cup/world-cup.component.spec.ts
+++ b/src/app/pages/league/world-cup/world-cup.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { LeagueHistoryService } from 'src/app/services/league-history.service';
 
 import { WorldCupComponent } from './world-cup.component';
 
@@ -8,7 +12,15 @@ describe('WorldCupComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WorldCupComponent]
+      imports: [WorldCupComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: LeagueHistoryService,
+          useValue: { getWorldCupDivisions: () => of([]), getMatchupHistory: () => of([]) },
+        },
+      ],
     })
     .compileComponents();
 

--- a/src/app/services/team-analysis.service.ts
+++ b/src/app/services/team-analysis.service.ts
@@ -82,12 +82,16 @@ export class TeamAnalysisService {
           continue // taxi never counts toward starter buckets
         }
 
+        if (reserve.has(pid)) {
+          continue // reserve (IR) players excluded from all buckets
+        }
+
         // Position: player map first, FantasyCalc fallback (mirrors iOS)
         const rawPos =
           playerMap[pid]?.position ?? this.valuesService.position(pid) ?? '?'
         const pos = rawPos.toUpperCase()
 
-        const onBench = !starters.has(pid) && !reserve.has(pid)
+        const onBench = !starters.has(pid)
 
         switch (pos) {
           case 'QB':


### PR DESCRIPTION
## Summary
- 7 auto-generated component specs missing `provideHttpClient()`/`provideHttpClientTesting()` — caused `NullInjectorError: No provider for HttpClient!` on every CI run
- `StandingsComponent` spec also needed `provideRouter([])` (injects `Router`)
- `MatchupsComponent`, `WorldCupComponent`, `RuleProposalsComponent` specs additionally needed stub providers for `LeagueHistoryService` / `SupabaseService` — both call `createClient()` at construction time, which throws with the placeholder `'---'` Supabase URL in the committed `environment.ts`
- Fixed a real logic bug in `TeamAnalysisService.build()`: reserve (IR) players were falling through to the position `switch` and being counted toward starter position buckets instead of being skipped entirely

## Test plan
- [x] `ng test --no-watch --browsers=ChromeHeadless` passes locally: **83 of 83 SUCCESS**
- [x] Deploy Frontend workflow should go green on merge — `ng test` was the only failing gate

Closes #104