### PR TITLE
fix(admin): drop test_mode toggle from cron settings

### DIFF
--- a/src/app/pages/admin/cron-settings/admin-cron-settings.component.html
+++ b/src/app/pages/admin/cron-settings/admin-cron-settings.component.html
@@ -1,9 +1,4 @@
 <div class="cron-settings">
-  <!-- Test-mode sticky banner -->
-  <div *ngIf="anyTestModeActive" class="test-mode-banner">
-    Test mode active — deliveries restricted to admin only
-  </div>
-
   <div class="page-header">
     <h2>Cron Settings</h2>
   </div>
@@ -28,6 +23,11 @@
     <p>No cron settings found.</p>
   </div>
 
+  <!-- Preview hint -->
+  <p *ngIf="!isLoading && !tableMissing && !error && rows.length > 0" class="preview-hint">
+    To preview an email, use <a routerLink="/admin/test-email" class="preview-hint__link">Admin → Test Email</a>.
+  </p>
+
   <!-- Rows -->
   <ul *ngIf="!isLoading && !tableMissing && !error && rows.length > 0" class="row-list">
     <li *ngFor="let row of rows" class="row-item">
@@ -49,19 +49,6 @@
               [class.toggle--off]="!row.enabled"
               (click)="toggleEnabled(row)"
               title="{{ row.enabled ? 'Disable' : 'Enable' }} cron"
-            ></button>
-          </div>
-
-          <!-- Test mode toggle (disabled when cron is off) -->
-          <div class="toggle-group" [class.toggle-group--disabled]="!row.enabled">
-            <span class="toggle-label" [class.toggle-label--off]="!row.testMode">Test</span>
-            <button
-              class="toggle"
-              [class.toggle--on]="row.testMode && row.enabled"
-              [class.toggle--off]="!row.testMode || !row.enabled"
-              [disabled]="!row.enabled"
-              (click)="toggleTestMode(row)"
-              title="Toggle test mode"
             ></button>
           </div>
         </ng-container>

--- a/src/app/pages/admin/cron-settings/admin-cron-settings.component.scss
+++ b/src/app/pages/admin/cron-settings/admin-cron-settings.component.scss
@@ -7,19 +7,6 @@
   margin: 0 auto;
 }
 
-.test-mode-banner {
-  background: rgba($champion-gold, 0.1);
-  border-bottom: 1px solid rgba($champion-gold, 0.3);
-  color: $champion-gold;
-  font-size: $text-sm;
-  font-weight: 600;
-  text-align: center;
-  padding: 10px $spacing-md;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-
 .page-header {
   padding: $spacing-lg $spacing-lg $spacing-sm;
   h2 { margin: 0; font-family: $font-display; font-size: 1.5rem; font-weight: 600; color: $text-primary; }
@@ -49,6 +36,20 @@
   transition: background $transition-fast;
 
   &:hover { background: rgba($surface-light, 0.3); }
+}
+
+.preview-hint {
+  margin: 0 $spacing-lg $spacing-sm;
+  font-size: $text-sm;
+  color: $text-muted;
+
+  &__link {
+    color: $text-secondary;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+
+    &:hover { color: $text-primary; }
+  }
 }
 
 .row-list {

--- a/src/app/pages/admin/cron-settings/admin-cron-settings.component.ts
+++ b/src/app/pages/admin/cron-settings/admin-cron-settings.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core'
 import { CommonModule } from '@angular/common'
+import { RouterLink } from '@angular/router'
 import { CronService } from 'src/app/services/cron.service'
 import { CronSetting, cronDisplayTitle } from 'src/app/models/cron-setting.model'
 import {
@@ -8,18 +9,16 @@ import {
 } from 'src/app/components/confirm-dialog/confirm-dialog.component'
 
 /**
- * Admin Cron Settings — per-row enabled/test-mode toggle pair.
+ * Admin Cron Settings — per-row enabled kill-switch.
  *
- * "Test mode active" gold sticky banner when any row has testMode=true.
  * Per-row pending spinner while an in-flight toggle call resolves.
  * ConfirmDialog before flipping `enabled` to false (kill-switch).
- *
- * Mirrors iOS CronSettingsView.swift + CronSettingsStore.swift.
+ * For email previews, use Admin → Test Email (/admin/test-email).
  */
 @Component({
   selector: 'app-admin-cron-settings',
   standalone: true,
-  imports: [CommonModule, ConfirmDialogComponent],
+  imports: [CommonModule, RouterLink, ConfirmDialogComponent],
   templateUrl: './admin-cron-settings.component.html',
   styleUrls: ['./admin-cron-settings.component.scss'],
 })
@@ -62,10 +61,6 @@ export class AdminCronSettingsComponent implements OnInit {
         this.isLoading = false
       },
     })
-  }
-
-  get anyTestModeActive(): boolean {
-    return this.rows.some((r) => r.testMode)
   }
 
   displayTitle(row: CronSetting): string {
@@ -116,32 +111,6 @@ export class AdminCronSettingsComponent implements OnInit {
         // Revert optimistic update.
         this.rows = this.rows.map((r) =>
           r.cronKey === cronKey ? { ...r, enabled: !enabled } : r,
-        )
-      },
-    })
-  }
-
-  toggleTestMode(row: CronSetting): void {
-    if (!row.enabled) return  // test-mode disabled when cron is off (iOS UX rule)
-    const newTestMode = !row.testMode
-    const cronKey = row.cronKey
-    this.pendingKeys[cronKey] = true
-    // Optimistic.
-    this.rows = this.rows.map((r) =>
-      r.cronKey === cronKey ? { ...r, testMode: newTestMode } : r,
-    )
-    this.cronService.setTestMode(cronKey, newTestMode).subscribe({
-      next: (patch) => {
-        this.pendingKeys[cronKey] = false
-        this.rows = this.rows.map((r) =>
-          r.cronKey === cronKey ? { ...r, ...patch } : r,
-        )
-      },
-      error: () => {
-        this.pendingKeys[cronKey] = false
-        // Revert.
-        this.rows = this.rows.map((r) =>
-          r.cronKey === cronKey ? { ...r, testMode: !newTestMode } : r,
         )
       },
     })


### PR DESCRIPTION
## Summary
- Removes the per-row Test toggle and the gold "Test mode active" sticky banner from Cron Settings — these were passive UI for a backend flag that only restricts scheduled delivery recipients, which is confusing next to the dedicated Test Email screen
- Adds inline hint: "To preview an email, use Admin → Test Email" with a `routerLink` to `/admin/test-email`
- Keeps the per-row Enabled kill-switch, pending spinner, confirm dialog, and all `CronService` contract untouched
- `testMode` field left on the row model (backend still sends it) — just no longer surfaced or toggled

Mirrors iOS PR #141 which shipped the same removal.

Closes #142

## Test plan
- [ ] Cron Settings page renders — only Enabled toggle visible per row, no Test toggle
- [ ] Gold sticky banner is gone
- [ ] "To preview an email, use Admin → Test Email" hint appears below the header when rows are present; link navigates to `/admin/test-email`
- [ ] Enabled toggle still works (enable/disable with confirm dialog on disable)
- [ ] `npm run build` — passes (bundle warning pre-existing)
- [ ] `ng test` — 83/83 SUCCESS