### PR TITLE
fix(shell): gate chrome behind auth, drop footer, monochrome themed icons

### DIFF
--- a/src/app/components/shell-layout/shell-layout.component.html
+++ b/src/app/components/shell-layout/shell-layout.component.html
@@ -1,16 +1,19 @@
 <div class="shell">
-  <!-- Desktop persistent sidebar rail -->
-  <app-sidebar
-    *ngIf="!isMobile"
-    [sections]="sections"
-    [isAdmin]="isAdmin"
-    class="shell__sidebar"
-  ></app-sidebar>
+  <!-- Shell chrome: sidebar + topbar + drawer hidden until authenticated + off /login -->
+  <ng-container *ngIf="showChrome">
+    <!-- Desktop persistent sidebar rail -->
+    <app-sidebar
+      *ngIf="!isMobile"
+      [sections]="sections"
+      [isAdmin]="isAdmin"
+      class="shell__sidebar"
+    ></app-sidebar>
+  </ng-container>
 
-  <!-- Main column -->
+  <!-- Main column always renders (holds router-outlet) -->
   <div class="shell__main-col">
-    <!-- Mobile top bar with hamburger -->
-    <header *ngIf="isMobile" class="shell__topbar">
+    <!-- Mobile top bar with hamburger — chrome-gated -->
+    <header *ngIf="isMobile && showChrome" class="shell__topbar">
       <button
         class="hamburger"
         (click)="toggleDrawer()"
@@ -27,7 +30,9 @@
         (click)="goToSearch()"
         aria-label="Search"
       >
-        🔍
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" width="20" height="20">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803 7.5 7.5 0 0016.803 15.803z" />
+        </svg>
       </button>
     </header>
 
@@ -35,13 +40,11 @@
       <app-toast></app-toast>
       <router-outlet></router-outlet>
     </main>
-
-    <app-footer></app-footer>
   </div>
 
-  <!-- Mobile overlay drawer -->
+  <!-- Mobile overlay drawer — chrome-gated -->
   <app-mobile-drawer
-    *ngIf="isMobile"
+    *ngIf="isMobile && showChrome"
     [open]="drawerOpen"
     [sections]="sections"
     [isAdmin]="isAdmin"

--- a/src/app/components/shell-layout/shell-layout.component.ts
+++ b/src/app/components/shell-layout/shell-layout.component.ts
@@ -1,9 +1,10 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
 import { NgIf } from '@angular/common'
-import { Router, RouterOutlet } from '@angular/router'
+import { Router, RouterOutlet, NavigationEnd } from '@angular/router'
+import { BehaviorSubject, Subscription, combineLatest } from 'rxjs'
+import { filter } from 'rxjs/operators'
 import { SidebarComponent } from '../sidebar/sidebar.component'
 import { MobileDrawerComponent } from '../mobile-drawer/mobile-drawer.component'
-import { FooterComponent } from '../footer/footer.component'
 import { ToastComponent } from '../toast/toast.component'
 import { SIDEBAR_SECTIONS, SidebarSection } from '../sidebar/sidebar.entries'
 import { SupabaseService } from 'src/app/services/supabase.service'
@@ -20,18 +21,20 @@ const MOBILE_BREAKPOINT = 768
     RouterOutlet,
     SidebarComponent,
     MobileDrawerComponent,
-    FooterComponent,
     ToastComponent,
   ],
 })
 export class ShellLayoutComponent implements OnInit, OnDestroy {
   isMobile = false
   drawerOpen = false
+  /** True when authenticated AND not on /login — gates sidebar/topbar/drawer. */
+  showChrome = false
 
   readonly sections: SidebarSection[] = SIDEBAR_SECTIONS
 
   private mediaQuery!: MediaQueryList
   private mqListener!: (e: MediaQueryListEvent) => void
+  private chromeSub!: Subscription
 
   constructor(private supabase: SupabaseService, private router: Router) {}
 
@@ -41,15 +44,29 @@ export class ShellLayoutComponent implements OnInit, OnDestroy {
     this.mqListener = (e: MediaQueryListEvent) => {
       this.isMobile = e.matches
       if (!e.matches) {
-        // Desktop: close drawer if it was open from mobile
         this.drawerOpen = false
       }
     }
     this.mediaQuery.addEventListener('change', this.mqListener)
+
+    // Seed with current URL then track NavigationEnd events.
+    const url$ = new BehaviorSubject<string>(this.router.url)
+    this.router.events
+      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .subscribe(e => url$.next(e.urlAfterRedirects))
+
+    // showChrome is true only when the user is authenticated AND not on /login.
+    this.chromeSub = combineLatest([
+      this.supabase.currentUser$,
+      url$,
+    ]).subscribe(([user, url]) => {
+      this.showChrome = !!user && !url.startsWith('/login')
+    })
   }
 
   ngOnDestroy(): void {
     this.mediaQuery.removeEventListener('change', this.mqListener)
+    this.chromeSub?.unsubscribe()
   }
 
   get isAdmin(): boolean {

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -14,7 +14,9 @@
       (click)="onEntryClick()"
       aria-label="Search"
     >
-      🔍
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" width="20" height="20">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803 7.5 7.5 0 0016.803 15.803z" />
+      </svg>
     </a>
   </div>
 
@@ -31,7 +33,7 @@
             routerLinkActive="entry--active"
             (click)="onEntryClick()"
           >
-            <span class="entry-icon" aria-hidden="true">{{ entry.icon }}</span>
+            <span class="entry-icon" aria-hidden="true" [innerHTML]="safeIcon(entry)"></span>
             <span class="entry-label">{{ entry.label }}</span>
           </a>
         </li>
@@ -42,7 +44,12 @@
   <!-- Sticky footer — Settings -->
   <div class="sidebar-footer">
     <a class="entry" routerLink="/settings" routerLinkActive="entry--active" (click)="onEntryClick()">
-      <span class="entry-icon" aria-hidden="true">⚙️</span>
+      <span class="entry-icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" width="20" height="20">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+      </span>
       <span class="entry-label">Settings</span>
     </a>
   </div>

--- a/src/app/components/sidebar/sidebar.component.scss
+++ b/src/app/components/sidebar/sidebar.component.scss
@@ -154,10 +154,17 @@ ul {
 }
 
 .entry-icon {
-  font-size: $text-base;
-  width: 24px;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
   flex-shrink: 0;
+  // SVGs inherit currentColor from the parent .entry rule
+  svg {
+    width: 20px;
+    height: 20px;
+  }
 }
 
 .entry-label {

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { NgClass, NgFor, NgIf } from '@angular/common'
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser'
 import { RouterLink, RouterLinkActive } from '@angular/router'
 import { SupabaseService, Profile } from 'src/app/services/supabase.service'
 import { UserService } from 'src/app/services/user.service'
@@ -21,6 +22,7 @@ export class SidebarComponent {
   constructor(
     public supabase: SupabaseService,
     public userService: UserService,
+    private sanitizer: DomSanitizer,
   ) {}
 
   get profile(): Profile | null {
@@ -43,6 +45,11 @@ export class SidebarComponent {
 
   visibleEntries(section: SidebarSection): SidebarEntry[] {
     return section.entries.filter(e => !e.adminOnly || this.isAdmin)
+  }
+
+  /** Bypass Angular's HTML sanitizer for trusted inline SVG strings. */
+  safeIcon(entry: SidebarEntry): SafeHtml {
+    return this.sanitizer.bypassSecurityTrustHtml(entry.svg)
   }
 
   onEntryClick(): void {

--- a/src/app/components/sidebar/sidebar.entries.ts
+++ b/src/app/components/sidebar/sidebar.entries.ts
@@ -2,12 +2,15 @@
  * Sidebar entry data table — mirrors iOS TrayDestination order.
  * s3: all 9 league destinations now point at flat child routes under /league/...
  * Admin entries are filtered by ShellLayoutComponent based on SupabaseService.isAdmin.
+ * s10: emoji icons replaced with inline SVG (Heroicons outline style, monochrome).
  */
 
 export interface SidebarEntry {
   label: string
-  /** Icon glyph (emoji or icon name placeholder — swap in s10 for proper icon system). */
+  /** @deprecated emoji placeholder — use svg instead */
   icon: string
+  /** Inline SVG markup. Render with fill="currentColor" or stroke="currentColor". */
+  svg: string
   route: string
   queryParams?: Record<string, string>
   /** True for entries only visible to admins. */
@@ -23,6 +26,102 @@ export interface SidebarSection {
   adminOnly?: boolean
 }
 
+// Heroicons outline paths (24×24 viewBox, stroke-based, currentColor).
+const ICONS = {
+  // Home — house outline
+  home: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955a1.126 1.126 0 011.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+  </svg>`,
+
+  // Standings — trophy outline
+  standings: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 18.75h-9m9 0a3 3 0 013 3h-15a3 3 0 013-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 01-.982-3.172M9.497 14.25a7.454 7.454 0 00.981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 007.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 002.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 012.916.52 6.003 6.003 0 01-5.395 4.972m0 0a6.726 6.726 0 01-2.749 1.35m0 0a6.772 6.772 0 01-3.044 0" />
+  </svg>`,
+
+  // Matchups — crossed swords / versus (bolt vs shield)
+  matchups: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
+  </svg>`,
+
+  // Playoffs — bracket / signal bars
+  playoffs: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+  </svg>`,
+
+  // Draft History — clipboard list
+  draftHistory: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" />
+  </svg>`,
+
+  // World Cup — globe
+  worldCup: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
+  </svg>`,
+
+  // My Team — users/people
+  myTeam: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
+  </svg>`,
+
+  // Taxi Squad — truck/van
+  taxiSquad: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 01-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 00-3.213-9.193 2.056 2.056 0 00-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 00-10.026 0 1.106 1.106 0 00-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12" />
+  </svg>`,
+
+  // Team Analyzer — chart / bar analytics
+  teamAnalyzer: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 14.25v2.25m3-4.5v4.5m3-6.75v6.75m3-9v9M6 20.25h12A2.25 2.25 0 0020.25 18V6A2.25 2.25 0 0018 3.75H6A2.25 2.25 0 003.75 6v12A2.25 2.25 0 006 20.25z" />
+  </svg>`,
+
+  // Rulebook — book open
+  rulebook: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+  </svg>`,
+
+  // Scoring — bolt / lightning
+  scoring: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
+  </svg>`,
+
+  // League Settings — cog / gear
+  settings: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />
+    <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+  </svg>`,
+
+  // Payouts — banknotes / currency
+  payouts: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />
+  </svg>`,
+
+  // Rule Proposals — document check / ballot
+  ruleProposals: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M10.125 2.25h-4.5c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125v-9M10.125 2.25h.375a9 9 0 019 9v.375M10.125 2.25A3.375 3.375 0 0113.5 5.625v1.5c0 .621.504 1.125 1.125 1.125h1.5a3.375 3.375 0 013.375 3.375M9 15l2.25 2.25L15 12" />
+  </svg>`,
+
+  // Draft Order — dice / random
+  draftOrder: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M21 7.5l-2.25-1.313M21 7.5v2.25m0-2.25l-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3l2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75l2.25-1.313M12 21.75V19.5m0 2.25l-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-9 5.25-9-5.25v-2.25l9-5.25 9 5.25z" />
+  </svg>`,
+
+  // AI Review — sparkles / AI chip
+  aiReview: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z" />
+  </svg>`,
+
+  // Admin — wrench / tool
+  admin: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z" />
+  </svg>`,
+
+  // Search — magnifying glass
+  search: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803 7.5 7.5 0 0016.803 15.803z" />
+  </svg>`,
+}
+
+export const SIDEBAR_ICONS = ICONS
+
 export const SIDEBAR_SECTIONS: SidebarSection[] = [
   {
     title: 'Play',
@@ -30,32 +129,38 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
       {
         label: 'Home',
         icon: '🏠',
+        svg: ICONS.home,
         route: '/home',
       },
       {
         label: 'Standings',
         icon: '🏆',
+        svg: ICONS.standings,
         route: '/league/standings',
       },
       {
         label: 'Matchups',
         icon: '⚔️',
+        svg: ICONS.matchups,
         route: '/league/matchups',
       },
       {
         label: 'Playoffs',
         icon: '🎯',
+        svg: ICONS.playoffs,
         route: '/league/playoffs',
       },
       {
         label: 'Draft History',
         icon: '📋',
+        svg: ICONS.draftHistory,
         route: '/draft-history',
         // s4 restructures
       },
       {
         label: 'World Cup',
         icon: '🌍',
+        svg: ICONS.worldCup,
         route: '/league/world-cup',
       },
     ],
@@ -66,16 +171,19 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
       {
         label: 'My Team',
         icon: '👥',
+        svg: ICONS.myTeam,
         route: '/team',
       },
       {
         label: 'Taxi Squad',
         icon: '🚕',
+        svg: ICONS.taxiSquad,
         route: '/taxi-squad',
       },
       {
         label: 'Team Analyzer',
         icon: '📊',
+        svg: ICONS.teamAnalyzer,
         route: '/team-analyzer',
       },
     ],
@@ -86,31 +194,37 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
       {
         label: 'Rulebook',
         icon: '📖',
+        svg: ICONS.rulebook,
         route: '/league/rulebook',
       },
       {
         label: 'Scoring',
         icon: '⚡',
+        svg: ICONS.scoring,
         route: '/league/scoring',
       },
       {
         label: 'League Settings',
         icon: '⚙️',
+        svg: ICONS.settings,
         route: '/league/settings',
       },
       {
         label: 'Payouts',
         icon: '💰',
+        svg: ICONS.payouts,
         route: '/league/payouts',
       },
       {
         label: 'Rule Proposals',
         icon: '🗳️',
+        svg: ICONS.ruleProposals,
         route: '/league/rule-proposals',
       },
       {
         label: 'Draft Order',
         icon: '🎲',
+        svg: ICONS.draftOrder,
         route: '/league/draft-order',
       },
     ],
@@ -122,12 +236,14 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
       {
         label: 'AI Review',
         icon: '🤖',
+        svg: ICONS.aiReview,
         route: '/ai-review',
         adminOnly: true,
       },
       {
         label: 'Admin',
         icon: '🔧',
+        svg: ICONS.admin,
         route: '/admin',
         adminOnly: true,
       },


### PR DESCRIPTION
## Summary

- **Fix 1 — Auth gate**: `showChrome` is derived from `combineLatest([currentUser$, url$])` in `ShellLayoutComponent.ngOnInit`. Sidebar, mobile topbar, and drawer are wrapped in `*ngIf="showChrome"`, which is `false` on `/login` or when unauthenticated. The `<router-outlet>` always renders bare so the login form displays without any chrome.
- **Fix 2 — Footer removed**: `<app-footer>` stripped from `shell-layout.component.html`. `FooterComponent` file untouched — still used by the legacy `?newShell=0` path in `app.component.html`.
- **Fix 3 — Monochrome icons**: All emoji replaced with Heroicons outline SVGs stored in `sidebar.entries.ts`. Icons use `stroke="currentColor"` so they inherit the muted text color by default and `--xomper-champion-gold` (`#00FFAB`) on `.entry--active`, matching the existing active-state rule. `DomSanitizer.bypassSecurityTrustHtml` used in `SidebarComponent` to render inline SVGs safely.

## Test plan

- [ ] Visit `/login` while logged out — no sidebar, no topbar, no drawer visible; just the login form
- [ ] Log in — chrome appears immediately without page reload
- [ ] Log out — chrome disappears, redirected to `/login` cleanly
- [ ] Mobile viewport: hamburger + topbar only appear when authenticated
- [ ] All sidebar icons render as clean monochrome outlines; active entry shows gold tint + left-bar indicator
- [ ] No footer visible anywhere in the shell

Closes #105

## Gates

- `npm run build` — passed (pre-existing bundle budget warning only)
- `ng test --no-watch --browsers=ChromeHeadless` — 83/83 SUCCESS