### PR TITLE
fix(league): bootstrap home league in AuthGuard so all tabs resolve leagueId

### DIFF
--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core'
 import { CanActivate, Router } from '@angular/router'
+import { Observable, catchError, map, of } from 'rxjs'
 import { SupabaseService } from '../services/supabase.service'
+import { LeagueService } from '../services/league.service'
 
 @Injectable({
   providedIn: 'root',
@@ -8,16 +10,19 @@ import { SupabaseService } from '../services/supabase.service'
 export class AuthGuard implements CanActivate {
   constructor(
     private supabaseService: SupabaseService,
+    private leagueService: LeagueService,
     private router: Router,
   ) {}
 
-  canActivate(): boolean {
-    if (this.supabaseService.isAuthenticated()) {
-      return true
+  canActivate(): Observable<boolean> {
+    if (!this.supabaseService.isAuthenticated()) {
+      this.router.navigate(['/login'])
+      return of(false)
     }
 
-    // s5: redirect unauthed users to /login (was /home pre-s5)
-    this.router.navigate(['/login'])
-    return false
+    return this.leagueService.loadMyLeague().pipe(
+      map(() => true),
+      catchError(() => of(true)),
+    )
   }
 }

--- a/src/app/services/league.service.ts
+++ b/src/app/services/league.service.ts
@@ -1,10 +1,13 @@
 import { Injectable } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
-import { Observable, EMPTY, map, of, forkJoin } from 'rxjs'
+import { Observable, EMPTY, map, of, forkJoin, switchMap } from 'rxjs'
 import { expand, reduce, tap } from 'rxjs/operators'
 import { Roster } from '../models/roster.interface'
 import { League } from '../models/league.interface'
 import { LeagueModel } from '../models/league.model'
+import { RosterModel } from '../models/roster.model'
+import { UserModel } from '../models/user.model'
+import { StandingsTeamModel } from '../models/standings.model'
 import { User } from '../models/user.interface'
 import { LeagueConfig } from '../models/league-config.interface'
 import { Matchup } from '../models/matchup.interface'
@@ -13,6 +16,9 @@ import { NflState } from '../models/nfl-state.interface'
 import { PlayoffBracketMatch } from '../models/playoff-bracket.interface'
 import { environment } from 'src/environments/environment'
 import { getCurrentSeason } from '../constants/season'
+import { StandingsService } from './standings.service'
+import { UserService } from './user.service'
+import { TeamService } from './team.service'
 
 export interface Transaction {
   type: string
@@ -60,7 +66,12 @@ export class LeagueService {
     },
   }
 
-  constructor(private http: HttpClient) {}
+  constructor(
+    private http: HttpClient,
+    private standingsService: StandingsService,
+    private userService: UserService,
+    private teamService: TeamService,
+  ) {}
 
   // =========================================
   // API CALLS
@@ -208,6 +219,109 @@ export class LeagueService {
     this.currentLeague = null
     this.leagueState = null
     this.leagueChainCache = null
+  }
+
+  // =========================================
+  // HOME LEAGUE BOOTSTRAP
+  // =========================================
+
+  /**
+   * Idempotent bootstrap of the home (whitelisted) league.
+   * Returns immediately if myLeague is already fully loaded (has rosters).
+   * Otherwise fetches league → users → rosters → builds standings, then
+   * sets myLeague, myTeam. Single emission.
+   */
+  loadMyLeague(): Observable<LeagueModel> {
+    if (this.myLeague && this.myLeague.getRosters().length > 0) {
+      return of(this.myLeague)
+    }
+
+    return this.searchLeague(this.whitelistedLeagueId).pipe(
+      switchMap((league) => {
+        league.setDivisions()
+        return forkJoin({
+          users: this.findLeagueUsers(league.league_id),
+          rosters: this.findLeagueRosters(league.league_id),
+        }).pipe(
+          map(({ users, rosters }) => {
+            const userModels = users.map((u) => new UserModel(u))
+            league.setUsers(userModels)
+
+            const rosterModels = rosters.map((r) => new RosterModel(r))
+            league.setRosters(rosterModels)
+
+            const taxiIds = rosterModels.reduce(
+              (acc: string[], r) => acc.concat(r.taxi || []),
+              [],
+            )
+            league.setTaxiSquadIds(taxiIds)
+
+            const standings = this.buildStandingsForLeague(rosterModels, userModels, league)
+            const sortedStandings = this.standingsService.buildStandings(standings)
+            league.setStandingsTeams(sortedStandings)
+
+            this.setMyLeague(league)
+
+            const myUserName = this.userService.getMyUser()?.getUserName()
+            const myTeam = sortedStandings.find((t) => t.userName === myUserName)
+            if (myTeam) this.teamService.setMyTeam(myTeam)
+
+            return league
+          }),
+        )
+      }),
+    )
+  }
+
+  private buildStandingsForLeague(
+    rosters: RosterModel[],
+    users: UserModel[],
+    league: LeagueModel,
+  ): StandingsTeamModel[] {
+    return rosters.map((roster) => {
+      const user = users.find((u) => u.user_id === roster.owner_id)
+
+      let streakTotal = 0
+      let streakType: '' | 'win' | 'loss' = ''
+      const streakStr = roster.metadata?.streak as string | undefined
+      if (streakStr) {
+        const match = streakStr.match(/(\d+)([WL])/)
+        if (match) {
+          streakTotal = parseInt(match[1], 10)
+          streakType = match[2] === 'W' ? 'win' : 'loss'
+        }
+      }
+
+      const divisionIndex =
+        roster.settings?.division != null ? `division_${roster.settings.division}` : null
+      const divisionName = divisionIndex
+        ? String(league.metadata?.[divisionIndex] ?? 'Unknown Division')
+        : 'Unknown Division'
+      const divisionAvatar = divisionIndex
+        ? String(league.metadata?.[`${divisionIndex}_avatar`] ?? 'assets/img/nfl.png')
+        : 'assets/img/nfl.png'
+
+      return new StandingsTeamModel({
+        roster,
+        players: [],
+        user: new UserModel(user!),
+        league,
+        teamName: (user?.metadata?.team_name as string) || `${user?.display_name}'s Team`,
+        userName: user?.display_name || 'Unknown User',
+        avatar: user?.avatar ? this.userService.buildAvatar(user.avatar) : 'assets/img/nfl.png',
+        wins: roster.settings?.wins ?? 0,
+        losses: roster.settings?.losses ?? 0,
+        fpts: (roster.settings?.fpts ?? 0) + (roster.settings?.fpts_decimal ?? 0) / 100,
+        fptsAgainst:
+          (roster.settings?.fpts_against ?? 0) +
+          (roster.settings?.fpts_against_decimal ?? 0) / 100,
+        streak: { type: streakType, total: streakTotal },
+        divisionName,
+        divisionAvatar,
+        leagueRank: -1,
+        divisionRank: -1,
+      })
+    })
   }
 
   // =========================================


### PR DESCRIPTION
## Summary
- `GET /v1/league/undefined` 404s on all non-`/league/*` routes because `myLeague` was only populated by `LeagueComponent.setupLeague()`, which never ran before other tabs called `getMyLeague()` synchronously in `ngOnInit`.
- Added `LeagueService.loadMyLeague()`: idempotent (returns immediately if rosters already loaded), otherwise fetches league → users + rosters in parallel via `forkJoin`, builds standings using the shared private `buildStandingsForLeague()` helper and `StandingsService.buildStandings()`, sets `myLeague` and `myTeam`. Single-emission Observable.
- `AuthGuard.canActivate()` now returns `Observable<boolean>`, calls `loadMyLeague()` on every authed route activation (idempotent = instant on repeat), with `catchError(() => of(true))` so a league hiccup never blocks navigation.

## Notes
- `LeagueComponent` is untouched — its `setupLeague()`/`getLeagueUsers()`/`getLeagueRosters()` flow continues to run on `/league/*` routes unchanged; calling `setMyLeague()` again is idempotent.
- The standings-build logic was duplicated into a private service method (`buildStandingsForLeague`) rather than extracted from `LeagueComponent` — the component's method is tightly coupled to `this.mode` branching and toast callbacks, making a true extract-and-share impractical without more surgery.
- `selected-*` / `currentLeague` paths are untouched.

## Test plan
- [ ] `/team`, `/draft-history`, `/team-analyzer`, `/league/standings`, `/league/matchups`, `/league/playoffs`, `/home` all read a populated `getMyLeague()` — no `/league/undefined` requests
- [ ] Guest/search (`currentLeague`) paths unaffected
- [ ] `ng test`: 83/83 SUCCESS
- [ ] `npm run build`: clean (pre-existing bundle size warning only)

Closes #141