### PR TITLE
Replace emoji with SVG icons

### DIFF
--- a/src/app/components/sidebar/sidebar.entries.ts
+++ b/src/app/components/sidebar/sidebar.entries.ts
@@ -7,8 +7,6 @@
 
 export interface SidebarEntry {
   label: string
-  /** @deprecated emoji placeholder — use svg instead */
-  icon: string
   /** Inline SVG markup. Render with fill="currentColor" or stroke="currentColor". */
   svg: string
   route: string
@@ -128,38 +126,32 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
     entries: [
       {
         label: 'Home',
-        icon: '🏠',
         svg: ICONS.home,
         route: '/home',
       },
       {
         label: 'Standings',
-        icon: '🏆',
         svg: ICONS.standings,
         route: '/league/standings',
       },
       {
         label: 'Matchups',
-        icon: '⚔️',
         svg: ICONS.matchups,
         route: '/league/matchups',
       },
       {
         label: 'Playoffs',
-        icon: '🎯',
         svg: ICONS.playoffs,
         route: '/league/playoffs',
       },
       {
         label: 'Draft History',
-        icon: '📋',
         svg: ICONS.draftHistory,
         route: '/draft-history',
         // s4 restructures
       },
       {
         label: 'World Cup',
-        icon: '🌍',
         svg: ICONS.worldCup,
         route: '/league/world-cup',
       },
@@ -170,19 +162,16 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
     entries: [
       {
         label: 'My Team',
-        icon: '👥',
         svg: ICONS.myTeam,
         route: '/team',
       },
       {
         label: 'Taxi Squad',
-        icon: '🚕',
         svg: ICONS.taxiSquad,
         route: '/taxi-squad',
       },
       {
         label: 'Team Analyzer',
-        icon: '📊',
         svg: ICONS.teamAnalyzer,
         route: '/team-analyzer',
       },
@@ -193,37 +182,31 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
     entries: [
       {
         label: 'Rulebook',
-        icon: '📖',
         svg: ICONS.rulebook,
         route: '/league/rulebook',
       },
       {
         label: 'Scoring',
-        icon: '⚡',
         svg: ICONS.scoring,
         route: '/league/scoring',
       },
       {
         label: 'League Settings',
-        icon: '⚙️',
         svg: ICONS.settings,
         route: '/league/settings',
       },
       {
         label: 'Payouts',
-        icon: '💰',
         svg: ICONS.payouts,
         route: '/league/payouts',
       },
       {
         label: 'Rule Proposals',
-        icon: '🗳️',
         svg: ICONS.ruleProposals,
         route: '/league/rule-proposals',
       },
       {
         label: 'Draft Order',
-        icon: '🎲',
         svg: ICONS.draftOrder,
         route: '/league/draft-order',
       },
@@ -235,14 +218,12 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
     entries: [
       {
         label: 'AI Review',
-        icon: '🤖',
         svg: ICONS.aiReview,
         route: '/ai-review',
         adminOnly: true,
       },
       {
         label: 'Admin',
-        icon: '🔧',
         svg: ICONS.admin,
         route: '/admin',
         adminOnly: true,

--- a/src/app/components/styled-markdown/markdown-reflow.ts
+++ b/src/app/components/styled-markdown/markdown-reflow.ts
@@ -23,6 +23,9 @@ export function paragraphs(raw: string): string {
   let out = raw
 
   // 1. Detach a leading title that's glued to the first sentence
+  //    NOTE: the emoji in the character class below are INPUT being
+  //    matched — AI-generated recaps arrive containing them — not UI we
+  //    render. Do not strip them in an emoji sweep; that breaks reflow.
   //    e.g. "2025 Rookie Draft RecapThe 2025 class…"
   out = out.replace(/(Recap|Standings|Summary|Review)([A-Z\u{1F3C6}\u{1F947}\u{1F948}\u{1F949}⚡️])/gu, '$1\n\n$2')
 

--- a/src/app/pages/admin/admin.component.html
+++ b/src/app/pages/admin/admin.component.html
@@ -12,7 +12,7 @@
       [disabled]="tile.disabled ?? false"
       (click)="navigate(tile)"
     >
-      <span class="tile-icon">{{ tile.icon }}</span>
+      <span class="tile-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor"><path [attr.d]="tile.iconPath"/></svg></span>
       <span class="tile-label">{{ tile.label }}</span>
       <span class="tile-subtitle">{{ tile.subtitle }}</span>
     </button>

--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -5,7 +5,8 @@ import { Router, RouterModule } from '@angular/router'
 interface AdminTile {
   label: string
   subtitle: string
-  icon: string
+  /** SVG path data, not emoji — emoji are not used in Xomware product UI. */
+  iconPath: string
   route: string | null
   /** Logs tile is deferred per D-D. */
   disabled?: boolean
@@ -32,49 +33,49 @@ export class AdminComponent {
     {
       label: 'AI Review',
       subtitle: 'Trigger + preview reports',
-      icon: '🤖',
+      iconPath: 'M21 10.5h-1V8c0-1.1-.9-2-2-2h-2.5V5c0-1.66-1.34-3-3-3S9.5 3.34 9.5 5v1H7c-1.1 0-2 .9-2 2v2.5H4c-1.1 0-2 .9-2 2s.9 2 2 2h1V17c0 1.1.9 2 2 2h2.5v1c0 1.66 1.34 3 3 3s3-1.34 3-3v-1H18c1.1 0 2-.9 2-2v-2.5h1c1.1 0 2-.9 2-2s-.9-2-2-2zM9 9h2v2H9V9zm4 6h-2v-2h2v2zm2-4h-2V9h2v2z',
       route: '/admin/ai-review',
     },
     {
       label: 'Test Email',
       subtitle: 'Send test emails',
-      icon: '✉️',
+      iconPath: 'M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z',
       route: '/admin/test-email',
     },
     {
       label: 'Email Archive',
       subtitle: 'Browse + resend emails',
-      icon: '📬',
+      iconPath: 'M20 2H4c-1 0-2 .9-2 2v3.01c0 .72.43 1.34 1 1.69V20c0 1.1 1.1 2 2 2h14c.9 0 2-.9 2-2V8.7c.57-.35 1-.97 1-1.69V4c0-1.1-1-2-2-2zm-5 12H9v-2h6v2zm5-7H4V4h16v3z',
       route: '/admin/email-archive',
     },
     {
       label: 'Announcements',
       subtitle: 'Create + manage banners',
-      icon: '📢',
+      iconPath: 'M18 11v2h4v-2h-4zm-2 6.61c.96.71 2.21 1.65 3.2 2.39.4-.53.8-1.07 1.2-1.6-.99-.74-2.24-1.68-3.2-2.4-.4.54-.8 1.08-1.2 1.61zM20.4 5.6c-.4-.53-.8-1.07-1.2-1.6-.99.74-2.24 1.68-3.2 2.4.4.53.8 1.07 1.2 1.6.96-.72 2.21-1.65 3.2-2.4zM4 9c-1.1 0-2 .9-2 2v2c0 1.1.9 2 2 2h1v4h2v-4h1l5 3V6L8 9H4zm11.5 3c0-1.33-.58-2.53-1.5-3.35v6.69c.92-.81 1.5-2.01 1.5-3.34z',
       route: '/admin/announcements',
     },
     {
       label: 'Tables',
       subtitle: 'Users + leagues',
-      icon: '🗃️',
+      iconPath: 'M20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM8 20H4v-4h4v4zm0-6H4v-4h4v4zm0-6H4V4h4v4zm6 12h-4v-4h4v4zm0-6h-4v-4h4v4zm0-6h-4V4h4v4zm6 12h-4v-4h4v4zm0-6h-4v-4h4v4zm0-6h-4V4h4v4z',
       route: '/admin/tables',
     },
     {
       label: 'Audit',
       subtitle: 'Admin action history',
-      icon: '🔍',
+      iconPath: 'M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z',
       route: '/admin/audit',
     },
     {
       label: 'Cron Settings',
       subtitle: 'Kill switches + test mode',
-      icon: '⏱️',
+      iconPath: 'M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z',
       route: '/admin/cron-settings',
     },
     {
       label: 'Logs',
       subtitle: 'Coming soon',
-      icon: '🖥️',
+      iconPath: 'M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z',
       route: null,
       disabled: true,
     },

--- a/src/app/pages/draft-history/recap/draft-recap.component.html
+++ b/src/app/pages/draft-history/recap/draft-recap.component.html
@@ -17,7 +17,7 @@
            Deferred — no web FantasyCalc values service exists.
            Follow-up: s4b-draft-grades. -->
       <div class="grades-deferred-notice">
-        <span class="notice-icon">ℹ️</span>
+        <span class="notice-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg></span>
         Draft grades coming in a future update.
       </div>
     </div>

--- a/src/app/pages/league/draft-order/draft-order.component.html
+++ b/src/app/pages/league/draft-order/draft-order.component.html
@@ -15,7 +15,7 @@
 
 <!-- Draft Order Pending — no points data yet -->
 <div class="draft-order-pending" *ngIf="!loading && !error && projection && !projection.hppDataAvailable">
-  <div class="pending-icon">📋</div>
+  <div class="pending-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor"><path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"/></svg></div>
   <h3 class="pending-title">Draft Order Pending</h3>
   <p class="pending-desc">Weekly scoring data is not yet available for this season. Check back once the regular season is underway.</p>
 </div>


### PR DESCRIPTION
Emoji aren't used in Xomware product UI.

## Admin tiles (8)

🤖 ✉️ 📬 📢 🗃️ 🔍 ⏱️ 📋 → SVG path data rendered through `[attr.d]`. Field renamed `icon` → `iconPath` so it's obvious it's no longer a glyph.

## Sidebar (17) — dead data, zero visual change

These lived in an `icon` field explicitly marked:

```ts
/** @deprecated emoji placeholder — use svg instead */
icon: string
```

The component renders `entry.svg`, not `entry.icon`. **They were never on screen.** Someone had already migrated this to SVG and left the emoji behind. Removed the values and the deprecated field.

## Two one-offs

The draft-order pending state (📋) and the draft-recap notice (ℹ️).

## Deliberately NOT touched

`markdown-reflow.ts` has emoji inside a **regex character class**:

```ts
out.replace(/(Recap|Standings|Summary|Review)([A-Z\u{1F3C6}\u{1F947}…⚡️])/gu, '$1\n\n$2')
```

Those are **input being matched** — AI-generated recaps arrive containing them — not UI we render. Stripping them would break the reflow. Added a comment saying so, because it looks exactly like a missed emoji to the next person running a sweep.

## Verified

All 10 visual baselines unchanged, which is the expected result: the sidebar emoji weren't rendering, and the admin/draft surfaces sit behind auth so they're outside the suite's coverage. Build clean.